### PR TITLE
fix: styled-componets DefaultTheme 타입 인식 문제 해결 및 레이아웃 크기 조정

### DIFF
--- a/src/components/common/Layout.styles.ts
+++ b/src/components/common/Layout.styles.ts
@@ -1,11 +1,10 @@
 import styled from 'styled-components';
 
 export const LayoutStyle = styled.div`
-  max-width: 1280px;
+  max-width: 1480px;
   width: 100%;
   margin-inline: auto; /* 좌우 가운데 정렬 */
   min-height: 100vh;
-  border: 1px solid #130e0e;
   text-align: center;
 `;
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,7 +10,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "types": ["node"],
+    "types": ["node" ,"styled-components"],
 
 
     /* Bundler mode */


### PR DESCRIPTION
## 📌 작업 내용
- styled-componets DefaultTheme 타입 인식 문제 해결
- 레이아웃 크기 조정

## 🔗 관련 이슈
- closes #3 
