### PR TITLE
release/2025-09-19: 코드리뷰 관련 부분적 리팩토링 진행

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -16,7 +16,7 @@ axiosInstance.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
-// 응답 인터셉터 (에러 처리용)
+// 응답 인터셉터
 axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
 const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_URL, 
-  withCredentials: false, 
+  baseURL: import.meta.env.VITE_API_URL,
+  withCredentials: false,
 });
 
 axiosInstance.interceptors.request.use(
@@ -14,6 +14,15 @@ axiosInstance.interceptors.request.use(
     return config;
   },
   (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터 (에러 처리용)
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    console.error('API Error:', error);
+    return Promise.reject(error);
+  }
 );
 
 export default axiosInstance;

--- a/src/api/productApi.ts
+++ b/src/api/productApi.ts
@@ -1,42 +1,10 @@
-import axios from 'axios';
+import axiosInstance from './axiosInstance';
 import type { Product, ProductResponse, ProductRequest } from '@/types/Product';
-
-// API 기본 설정
-const api = axios.create({
-  baseURL: 'https://team17be-production.up.railway.app',
-  timeout: 10000,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
-
-// 요청 인터셉터
-api.interceptors.request.use(
-  (config) => {
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
-
-// 응답 인터셉터
-api.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    console.error('API Error:', error);
-    return Promise.reject(error);
-  }
-);
 
 // 모든 제품 목록 조회
 export const fetchProducts = async (): Promise<ProductResponse> => {
   try {
-    const response = await api.get<ProductResponse>('/api/products');
+    const response = await axiosInstance.get<ProductResponse>('/api/products');
     return response.data;
   } catch (error) {
     console.error('Failed to fetch products:', error);
@@ -47,7 +15,7 @@ export const fetchProducts = async (): Promise<ProductResponse> => {
 // 특정 제품 조회
 export const fetchProductById = async (id: number): Promise<Product> => {
   try {
-    const response = await api.get<Product>(`/api/products/${id}`);
+    const response = await axiosInstance.get<Product>(`/api/products/${id}`);
     return response.data;
   } catch (error) {
     console.error(`Failed to fetch product ${id}:`, error);
@@ -58,7 +26,7 @@ export const fetchProductById = async (id: number): Promise<Product> => {
 // 제품 생성
 export const createProduct = async (data: ProductRequest): Promise<Product> => {
   try {
-    const response = await api.post<Product>('/api/products', data);
+    const response = await axiosInstance.post<Product>('/api/products', data);
     return response.data;
   } catch (error) {
     console.error('Failed to create product:', error);
@@ -72,7 +40,7 @@ export const updateProduct = async (
   data: Partial<ProductRequest>
 ): Promise<Product> => {
   try {
-    const response = await api.put<Product>(`/api/products/${id}`, data);
+    const response = await axiosInstance.put<Product>(`/api/products/${id}`, data);
     return response.data;
   } catch (error) {
     console.error(`Failed to update product ${id}:`, error);
@@ -83,7 +51,7 @@ export const updateProduct = async (
 // 제품 삭제
 export const deleteProduct = async (id: number): Promise<void> => {
   try {
-    await api.delete(`/api/products/${id}`);
+    await axiosInstance.delete(`/api/products/${id}`);
   } catch (error) {
     console.error(`Failed to delete product ${id}:`, error);
     throw new Error('제품 삭제에 실패했습니다.');
@@ -93,7 +61,7 @@ export const deleteProduct = async (id: number): Promise<void> => {
 // 제품 좋아요 토글
 export const toggleProductLike = async (id: number): Promise<{ likeCount: number }> => {
   try {
-    const response = await api.post<{ likeCount: number }>(`/api/products/${id}/like`);
+    const response = await axiosInstance.post<{ likeCount: number }>(`/api/products/${id}/like`);
     return response.data;
   } catch (error) {
     console.error(`Failed to toggle like for product ${id}:`, error);

--- a/src/api/starterPackApi.ts
+++ b/src/api/starterPackApi.ts
@@ -2,7 +2,7 @@ import axiosInstance from './axiosInstance';
 import type { StarterPack, StarterPackResponse, StarterPackRequest } from '@/types/StarterPack';
 
 // 모든 스타터팩 목록 조회
-export const fetchStarterPacks = async (): Promise<StarterPackResponse> => {
+export const fetchStarterPack = async (): Promise<StarterPackResponse> => {
   try {
     const response = await axiosInstance.get<StarterPackResponse>('/api/packs');
     return response.data;

--- a/src/api/starterPackApi.ts
+++ b/src/api/starterPackApi.ts
@@ -1,43 +1,10 @@
-import axios from 'axios';
+import axiosInstance from './axiosInstance';
 import type { StarterPack, StarterPackResponse, StarterPackRequest } from '@/types/StarterPack';
-
-// API 기본 설정
-const api = axios.create({
-  baseURL: 'https://team17be-production.up.railway.app',
-  timeout: 10000,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
-
-// 요청 인터셉터
-api.interceptors.request.use(
-  (config) => {
-    // 토큰이 있다면 헤더에 추가
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
-
-// 응답 인터셉터 (에러 처리용)
-api.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    console.error('API Error:', error);
-    return Promise.reject(error);
-  }
-);
 
 // 모든 스타터팩 목록 조회
 export const fetchStarterPacks = async (): Promise<StarterPackResponse> => {
   try {
-    const response = await api.get<StarterPackResponse>('/api/packs');
+    const response = await axiosInstance.get<StarterPackResponse>('/api/packs');
     return response.data;
   } catch (error) {
     console.error('Failed to fetch starter packs:', error);
@@ -48,7 +15,7 @@ export const fetchStarterPacks = async (): Promise<StarterPackResponse> => {
 // 특정 스타터팩 조회
 export const fetchStarterPackById = async (id: number): Promise<StarterPack> => {
   try {
-    const response = await api.get<StarterPack>(`/api/packs/${id}`);
+    const response = await axiosInstance.get<StarterPack>(`/api/packs/${id}`);
     return response.data;
   } catch (error) {
     console.error(`Failed to fetch starter pack ${id}:`, error);
@@ -59,7 +26,7 @@ export const fetchStarterPackById = async (id: number): Promise<StarterPack> => 
 // 스타터팩 생성
 export const createStarterPack = async (data: StarterPackRequest): Promise<StarterPack> => {
   try {
-    const response = await api.post<StarterPack>('/api/packs', data);
+    const response = await axiosInstance.post<StarterPack>('/api/packs', data);
     return response.data;
   } catch (error) {
     console.error('Failed to create starter pack:', error);
@@ -73,7 +40,7 @@ export const updateStarterPack = async (
   data: Partial<StarterPackRequest>
 ): Promise<StarterPack> => {
   try {
-    const response = await api.put<StarterPack>(`/api/packs/${id}`, data);
+    const response = await axiosInstance.put<StarterPack>(`/api/packs/${id}`, data);
     return response.data;
   } catch (error) {
     console.error(`Failed to update starter pack ${id}:`, error);
@@ -84,7 +51,7 @@ export const updateStarterPack = async (
 // 스타터팩 삭제
 export const deleteStarterPack = async (id: number): Promise<void> => {
   try {
-    await api.delete(`/api/packs/${id}`);
+    await axiosInstance.delete(`/api/packs/${id}`);
   } catch (error) {
     console.error(`Failed to delete starter pack ${id}:`, error);
     throw new Error('스타터팩 삭제에 실패했습니다.');
@@ -94,7 +61,7 @@ export const deleteStarterPack = async (id: number): Promise<void> => {
 // 스타터팩 좋아요 토글
 export const toggleStarterPackLike = async (id: number): Promise<{ likes: number }> => {
   try {
-    const response = await api.post<{ likes: number }>(`/api/packs/${id}/like`);
+    const response = await axiosInstance.post<{ likes: number }>(`/api/packs/${id}/like`);
     return response.data;
   } catch (error) {
     console.error(`Failed to toggle like for starter pack ${id}:`, error);

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -1,0 +1,221 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+// 비동기 상태 타입 정의
+export interface AsyncState<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export interface UseAsyncOptions<T> {
+  initialData?: T | null;
+  immediate?: boolean;
+  errorMessage?: (error: unknown) => string;
+  onSuccess?: (data: T) => void;
+  onError?: (error: string) => void;
+}
+
+export interface UseAsyncReturn<T, Args extends unknown[] = []> extends AsyncState<T> {
+  execute: (...args: Args) => Promise<T | null>;
+  reset: () => void;
+  setData: (data: T | null) => void;
+  setError: (error: string | null) => void;
+}
+
+export function useAsync<T>(
+  asyncFunction: () => Promise<T>,
+  options?: UseAsyncOptions<T> & { immediate?: boolean }
+): UseAsyncReturn<T, []>;
+
+export function useAsync<T, Args extends unknown[]>(
+  asyncFunction: (...args: Args) => Promise<T>,
+  options?: UseAsyncOptions<T> & { immediate?: boolean }
+): UseAsyncReturn<T, Args>;
+
+/**
+ * 비동기 함수의 상태를 관리하는 커스텀 훅
+ * @param asyncFunction - 실행할 비동기 함수
+ * @param options - 옵션 설정
+ * @returns 비동기 상태와 제어 함수들
+ */
+export function useAsync<T, Args extends unknown[] = []>(
+  asyncFunction: (...args: Args) => Promise<T>,
+  options: UseAsyncOptions<T> & { immediate?: boolean } = {}
+): UseAsyncReturn<T, Args> {
+  const {
+    initialData = null,
+    immediate = true,
+    errorMessage = (error: unknown) =>
+      error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.',
+    onSuccess,
+    onError,
+  } = options;
+
+  const [data, setData] = useState<T | null>(initialData);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 요청 취소 및 순서 관리를 위한 ref
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const requestIdRef = useRef(0);
+
+  // 비동기 함수 실행
+  const execute = useCallback(
+    async (...args: Args): Promise<T | null> => {
+      // 이전 요청 취소
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+
+      // 새로운 AbortController 생성
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
+      // 요청 ID 증가 (race condition 방지)
+      const currentRequestId = ++requestIdRef.current;
+
+      try {
+        setLoading(true);
+        setError(null);
+
+        // asyncFunction이 AbortSignal을 지원하는지 확인
+        const result = await asyncFunction(...args);
+
+        // 요청이 취소되었거나 더 최신 요청이 있으면 무시
+        if (abortController.signal.aborted || currentRequestId !== requestIdRef.current) {
+          return null;
+        }
+
+        setData(result);
+        onSuccess?.(result);
+        return result;
+      } catch (err) {
+        // 요청이 취소되었거나 더 최신 요청이 있으면 무시
+        if (abortController.signal.aborted || currentRequestId !== requestIdRef.current) {
+          return null;
+        }
+
+        const errorMsg = errorMessage(err);
+        setError(errorMsg);
+        onError?.(errorMsg);
+        return null;
+      } finally {
+        // 현재 요청이 최신 요청인 경우에만 로딩 상태 해제
+        if (currentRequestId === requestIdRef.current) {
+          setLoading(false);
+        }
+      }
+    },
+    [asyncFunction, errorMessage, onSuccess, onError]
+  );
+
+  // 상태 리셋
+  const reset = useCallback(() => {
+    // 진행 중인 요청 취소
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+
+    setData(initialData);
+    setLoading(false);
+    setError(null);
+  }, [initialData]);
+
+  // 컴포넌트 언마운트 시 취소
+  useEffect(() => {
+    return () => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    };
+  }, []);
+
+  // immediate가 true면 자동 실행
+  useEffect(() => {
+    if (immediate) {
+      // immediate 실행 시에는 인자 없이 호출
+      // 타입 레벨에서 인자 없는 함수인지 확인
+      void execute(...([] as unknown as Args));
+    }
+  }, [immediate, execute]);
+
+  return {
+    data,
+    loading,
+    error,
+    execute,
+    reset,
+    setData,
+    setError,
+  };
+}
+
+// CRUD 액션을 위한 useAsyncActions 훅
+export interface UseAsyncActionsOptions {
+  // 에러 메시지 변환 함수
+  errorMessage?: (error: unknown) => string;
+  // 성공 시 콜백
+  onSuccess?: (action: string, data?: unknown) => void;
+  // 실패 시 콜백
+  onError?: (action: string, error: string) => void;
+}
+
+export interface UseAsyncActionsReturn {
+  // 로딩 상태
+  loading: boolean;
+  // 에러 상태
+  error: string | null;
+  // 액션 실행 함수
+  execute: <T>(action: () => Promise<T>) => Promise<T | null>;
+  // 에러 리셋
+  clearError: () => void;
+}
+
+/**
+ * CRUD 액션을 위한 비동기 상태 관리 훅
+ * @param options - 옵션 설정
+ * @returns 액션 상태와 실행 함수
+ */
+export function useAsyncActions(options: UseAsyncActionsOptions = {}): UseAsyncActionsReturn {
+  const {
+    errorMessage = (error: unknown) =>
+      error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.',
+    onSuccess,
+    onError,
+  } = options;
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const execute = useCallback(
+    async <T>(action: () => Promise<T>): Promise<T | null> => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const result = await action();
+        onSuccess?.('execute', result);
+        return result;
+      } catch (err) {
+        const errorMsg = errorMessage(err);
+        setError(errorMsg);
+        onError?.('execute', errorMsg);
+        return null;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [errorMessage, onSuccess, onError]
+  );
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return {
+    loading,
+    error,
+    execute,
+    clearError,
+  };
+}

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState } from 'react';
+import { useAsync, useAsyncActions } from './useAsync';
 import {
   fetchProducts,
   fetchProductById,
@@ -7,143 +8,80 @@ import {
   deleteProduct,
   toggleProductLike,
 } from '@/api/productApi';
-import type { Product, ProductResponse, ProductRequest } from '@/types/Product';
+import type { ProductRequest } from '@/types/Product';
 
 // 모든 제품 목록 관리
 export const useProducts = () => {
-  const [products, setProducts] = useState<ProductResponse>({});
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const loadProducts = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const data = await fetchProducts();
-      setProducts(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : '제품을 불러오는데 실패했습니다.');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    loadProducts();
-  }, [loadProducts]);
-
-  const refresh = useCallback(() => {
-    loadProducts();
-  }, [loadProducts]);
-
-  return {
-    products,
+  const {
+    data: products,
     loading,
     error,
-    refresh,
+    execute,
+    reset,
+  } = useAsync(fetchProducts, {
+    initialData: {},
+    errorMessage: () => '제품을 불러오는 데 실패했습니다.',
+  });
+
+  return {
+    products: products || {},
+    loading,
+    error,
+    refresh: execute,
+    reset,
   };
 };
 
 // 단일 제품 관리
 export const useProduct = (id: number) => {
-  const [product, setProduct] = useState<Product | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const loadProduct = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const data = await fetchProductById(id);
-      setProduct(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : '제품을 불러오는데 실패했습니다.');
-    } finally {
-      setLoading(false);
-    }
-  }, [id]);
-
-  useEffect(() => {
-    if (id) {
-      loadProduct();
-    }
-  }, [id, loadProduct]);
-
-  const refresh = useCallback(() => {
-    loadProduct();
-  }, [loadProduct]);
+  const {
+    data: product,
+    loading,
+    error,
+    execute,
+    reset,
+  } = useAsync(() => fetchProductById(id), {
+    immediate: !!id,
+    errorMessage: () => '제품을 불러오는 데 실패했습니다.',
+  });
 
   return {
     product,
     loading,
     error,
-    refresh,
+    refresh: execute,
+    reset,
   };
 };
 
 // 제품 CRUD 작업 관리
 export const useProductActions = () => {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { loading, error, execute, clearError } = useAsyncActions({
+    errorMessage: (error: unknown) =>
+      error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.',
+  });
 
-  const create = useCallback(async (data: ProductRequest) => {
-    try {
-      setLoading(true);
-      setError(null);
-      const result = await createProduct(data);
-      return result;
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : '제품 생성에 실패했습니다.';
-      setError(errorMessage);
-      throw new Error(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const create = async (data: ProductRequest) => {
+    const result = await execute(() => createProduct(data));
+    if (!result) throw new Error('제품 생성에 실패했습니다.');
+    return result;
+  };
 
-  const update = useCallback(async (id: number, data: Partial<ProductRequest>) => {
-    try {
-      setLoading(true);
-      setError(null);
-      const result = await updateProduct(id, data);
-      return result;
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : '제품 수정에 실패했습니다.';
-      setError(errorMessage);
-      throw new Error(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const update = async (id: number, data: Partial<ProductRequest>) => {
+    const result = await execute(() => updateProduct(id, data));
+    if (!result) throw new Error('제품 수정에 실패했습니다.');
+    return result;
+  };
 
-  const remove = useCallback(async (id: number) => {
-    try {
-      setLoading(true);
-      setError(null);
-      await deleteProduct(id);
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : '제품 삭제에 실패했습니다.';
-      setError(errorMessage);
-      throw new Error(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const remove = async (id: number) => {
+    await execute(() => deleteProduct(id));
+  };
 
-  const toggleLike = useCallback(async (id: number) => {
-    try {
-      setLoading(true);
-      setError(null);
-      const result = await toggleProductLike(id);
-      return result;
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : '좋아요 처리에 실패했습니다.';
-      setError(errorMessage);
-      throw new Error(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const toggleLike = async (id: number) => {
+    const result = await execute(() => toggleProductLike(id));
+    if (!result) throw new Error('좋아요 처리에 실패했습니다.');
+    return result;
+  };
 
   return {
     create,
@@ -152,16 +90,21 @@ export const useProductActions = () => {
     toggleLike,
     loading,
     error,
+    clearError,
   };
 };
 
 // 제품 좋아요 관리
 export const useProductLike = (id: number, initialLikeCount: number = 0) => {
+  const { loading, error, execute } = useAsync(() => toggleProductLike(id), {
+    errorMessage: () => '좋아요 처리에 실패했습니다.',
+  });
+
+  // 로컬 상태로 낙관적 업데이트 관리
   const [likeCount, setLikeCount] = useState(initialLikeCount);
   const [isLiked, setIsLiked] = useState(false);
-  const [loading, setLoading] = useState(false);
 
-  const handleToggleLike = useCallback(async () => {
+  const handleToggleLike = async () => {
     if (loading) return;
 
     // 낙관적 업데이트
@@ -170,26 +113,26 @@ export const useProductLike = (id: number, initialLikeCount: number = 0) => {
 
     setIsLiked(newIsLiked);
     setLikeCount(newLikeCount);
-    setLoading(true);
 
-    try {
-      const result = await toggleProductLike(id);
+    // 서버 요청
+    const result = await execute();
+
+    if (result) {
+      // 성공 시 서버 데이터로 업데이트
       setLikeCount(result.likeCount);
       setIsLiked(result.likeCount > likeCount);
-    } catch (error) {
+    } else {
       // 실패 시 롤백
       setIsLiked(!newIsLiked);
       setLikeCount(likeCount);
-      console.error('Failed to toggle like:', error);
-    } finally {
-      setLoading(false);
     }
-  }, [id, isLiked, likeCount, loading]);
+  };
 
   return {
     likeCount,
     isLiked,
     loading,
+    error,
     toggleLike: handleToggleLike,
   };
 };

--- a/src/mocks/feedData.ts
+++ b/src/mocks/feedData.ts
@@ -1,5 +1,10 @@
 import type { FeedPost, FeedResponse, LikePostResponse } from '@/types/Feed';
 
+const FEED_API_DEFAULTS = {
+  DEFAULT_PAGE: 1,
+  DEFAULT_PAGE_SIZE: 10,
+} as const;
+
 // Mock 카테고리 데이터
 const mockCategories = [
   { categoryId: 1, categoryName: '패션' },
@@ -129,8 +134,8 @@ export const generateMockFeedResponse = (page: number = 1, limit: number = 10): 
 };
 
 export const fetchFeedPosts = async (
-  page: number = 1,
-  limit: number = 10
+  page: number = FEED_API_DEFAULTS.DEFAULT_PAGE,
+  limit: number = FEED_API_DEFAULTS.DEFAULT_PAGE_SIZE
 ): Promise<FeedResponse> => {
   await new Promise((resolve) => setTimeout(resolve, 800));
   return generateMockFeedResponse(page, limit);

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -15,12 +15,18 @@ import {
   EmptyState,
 } from './FeedPage.styles';
 
+const FEED_CONSTANTS = {
+  INITIAL_PAGE: 1,
+  INITIAL_PAGE_SIZE: 10, // 일단 10개로 표시되도록 설정했는데, FEED 테스트하며 적절한 숫자 찾아볼 것!
+  LOAD_MORE_PAGE_SIZE: 10, // 이것도 위와 마찬가지!
+} as const;
+
 const FeedPage = () => {
   const [posts, setPosts] = useState<FeedPostType[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState<number>(FEED_CONSTANTS.INITIAL_PAGE);
   const [hasNext, setHasNext] = useState(false);
 
   useEffect(() => {
@@ -29,7 +35,10 @@ const FeedPage = () => {
         setLoading(true);
         setError(null);
 
-        const response: FeedResponse = await fetchFeedPosts(1, 10);
+        const response: FeedResponse = await fetchFeedPosts(
+          FEED_CONSTANTS.INITIAL_PAGE,
+          FEED_CONSTANTS.INITIAL_PAGE_SIZE
+        );
 
         setPosts(response.feeds);
         setCurrentPage(response.currentPage);
@@ -49,7 +58,10 @@ const FeedPage = () => {
     if (hasNext && !loadingMore) {
       try {
         setLoadingMore(true);
-        const response: FeedResponse = await fetchFeedPosts(currentPage + 1, 10);
+        const response: FeedResponse = await fetchFeedPosts(
+          currentPage + 1,
+          FEED_CONSTANTS.LOAD_MORE_PAGE_SIZE
+        );
 
         setPosts((prev) => [...prev, ...response.feeds]);
         setCurrentPage(response.currentPage);


### PR DESCRIPTION
PR 템플릿에 맞춰서 작업 내용을 정리해드리겠습니다!

## #️⃣ 작업 내용

### API 클라이언트 통일
- 문제: 각 API 파일에서 중복된 axios 인스턴스 생성 및 하드코딩된 URL 사용
- 해결
  - `axiosInstance.ts` 공용 인스턴스 사용으로 통일
  - `productApi.ts`, `starterPackApi.ts` 리팩토링 완료

### 비동기 상태 관리 훅 개선
- 문제: 각 훅마다 `data`, `loading`, `error` 상태 중복 관리로 코드 파편화
- 해결
  - `useAsync` 커스텀 훅 생성으로 중복 코드 제거
  - `useAsyncActions` 훅으로 CRUD 액션 통합 관리
  - Race condition 해결 (AbortController + 요청 ID로 순서 보장)
  - 함수 오버로딩으로 타입 안전성 확보

### 매직 넘버 제거
- 문제: `fetchFeedPosts(1, 10)` 등 매직 넘버로 인한 의도 불분명
- 해결
  - `FEED_CONSTANTS` 상수 객체로 분리
  - 각 값의 의미와 정책을 주석으로 명시
  - API 기본값도 별도 상수로 관리

### 함수명 일관성 개선
- 문제: `fetchStarterPacks`만 복수형 사용 (일관성 부족)
- 해결
  - `fetchStarterPacks` → `fetchStarterPack`으로 변경
  - `useStarterPacks` → `useStarterPack`으로 변경
  - `useStarterPack` → `useStarterPackById`로 변경