### PR TITLE
취미팩 작성에서 이미지 업로드 기능 추가

### DIFF
--- a/src/components/feedwriting/ThumbnailImage.tsx
+++ b/src/components/feedwriting/ThumbnailImage.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect } from 'react';
 import { Desc, TitleStyle } from '@/components/feedwriting/Title.style';
-import { ImageUploadBox } from '@/components/feedwriting/UploadBox.style';
+import { ImageUploadBox, ScrollContainer } from '@/components/feedwriting/UploadBox.style';
 
 const ThumbnailImage = () => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -31,22 +31,26 @@ const ThumbnailImage = () => {
       <TitleStyle>대표 이미지 업로드</TitleStyle>
       <ImageUploadBox onClick={handleBoxClick}>
         {previews.length > 0 ? (
-          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          <ScrollContainer>
             {previews.map((src, idx) => (
-              <img
-                key={idx}
-                src={src}
-                alt={`업로드 이미지 ${idx + 1}`}
-                style={{ width: 100, height: 100, objectFit: 'cover' }}
-              />
+              <div key={idx} style={{ flex: '0 0 80%' }}>
+                <img
+                  src={src}
+                  alt={idx === 0 ? '대표 이미지' : `첨부 이미지 ${idx}`}
+                  style={{
+                    width: '90%',
+                    height: '90%',
+                    objectFit: 'contain',                              
+                  }}
+                />
+              </div>
             ))}
-          </div>
+          </ScrollContainer>
         ) : (
           <Desc>
-            이미지를 업로드해주세요. <br /> (이미지 여러개 가능)
+            여러 장의 이미지를 업로드해주세요. <br /> (첫 번째가 대표 이미지)
           </Desc>
         )}
-
         <input
           type="file"
           accept="image/*"

--- a/src/components/feedwriting/ThumbnailImage.tsx
+++ b/src/components/feedwriting/ThumbnailImage.tsx
@@ -18,6 +18,8 @@ const ThumbnailImage = () => {
 
     const urls = fileArray.map((file) => URL.createObjectURL(file));
     setPreviews(urls);
+
+    e.currentTarget.value='';
   };
 
   useEffect(() => {

--- a/src/components/feedwriting/ThumbnailImage.tsx
+++ b/src/components/feedwriting/ThumbnailImage.tsx
@@ -1,11 +1,18 @@
+//import {useRef} from 'react';
 import { Desc, TitleStyle } from '@/components/feedwriting/Title.style';
 import { ImageUploadBox } from '@/components/feedwriting/UploadBox.style';
 
 const ThumbnailImage = () => {
+
+  //const fileInputRef = useRef<HTMLInputElement|null>(null);
+
+  const handleBoxClick = () =>{
+    console.log('boxclick')
+  }
   return (
     <>
       <TitleStyle>대표 이미지 업로드</TitleStyle>
-      <ImageUploadBox>
+      <ImageUploadBox onClick={handleBoxClick}>
         <Desc>
           대표 이미지를 업로드해주세요. <br /> 클릭 시 이미지 불러오기
         </Desc>

--- a/src/components/feedwriting/ThumbnailImage.tsx
+++ b/src/components/feedwriting/ThumbnailImage.tsx
@@ -1,22 +1,60 @@
-import { useRef } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { Desc, TitleStyle } from '@/components/feedwriting/Title.style';
 import { ImageUploadBox } from '@/components/feedwriting/UploadBox.style';
 
 const ThumbnailImage = () => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [previews, setPreviews] = useState<string[]>([]);
 
   const handleBoxClick = () => {
     fileInputRef.current?.click();
   };
 
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+
+    const fileArray = Array.from(files);
+
+    const urls = fileArray.map((file) => URL.createObjectURL(file));
+    setPreviews(urls);
+  };
+
+  useEffect(() => {
+    return () => {
+      previews.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, [previews]);
+
   return (
     <>
       <TitleStyle>대표 이미지 업로드</TitleStyle>
       <ImageUploadBox onClick={handleBoxClick}>
-        <Desc>
-          대표 이미지를 업로드해주세요. <br /> 클릭 시 이미지 불러오기
-        </Desc>
-        <input ref={fileInputRef} type="file" accept="image/*" style={{ display: 'none' }} />
+        {previews.length > 0 ? (
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+            {previews.map((src, idx) => (
+              <img
+                key={idx}
+                src={src}
+                alt={`업로드 이미지 ${idx + 1}`}
+                style={{ width: 100, height: 100, objectFit: 'cover' }}
+              />
+            ))}
+          </div>
+        ) : (
+          <Desc>
+            이미지를 업로드해주세요. <br /> (이미지 여러개 가능)
+          </Desc>
+        )}
+
+        <input
+          type="file"
+          accept="image/*"
+          multiple
+          ref={fileInputRef}
+          style={{ display: 'none' }}
+          onChange={handleFileChange}
+        />
       </ImageUploadBox>
     </>
   );

--- a/src/components/feedwriting/ThumbnailImage.tsx
+++ b/src/components/feedwriting/ThumbnailImage.tsx
@@ -1,14 +1,14 @@
-//import {useRef} from 'react';
+import { useRef } from 'react';
 import { Desc, TitleStyle } from '@/components/feedwriting/Title.style';
 import { ImageUploadBox } from '@/components/feedwriting/UploadBox.style';
 
 const ThumbnailImage = () => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  //const fileInputRef = useRef<HTMLInputElement|null>(null);
+  const handleBoxClick = () => {
+    fileInputRef.current?.click();
+  };
 
-  const handleBoxClick = () =>{
-    console.log('boxclick')
-  }
   return (
     <>
       <TitleStyle>대표 이미지 업로드</TitleStyle>
@@ -16,6 +16,7 @@ const ThumbnailImage = () => {
         <Desc>
           대표 이미지를 업로드해주세요. <br /> 클릭 시 이미지 불러오기
         </Desc>
+        <input ref={fileInputRef} type="file" accept="image/*" style={{ display: 'none' }} />
       </ImageUploadBox>
     </>
   );

--- a/src/components/feedwriting/UploadBox.style.ts
+++ b/src/components/feedwriting/UploadBox.style.ts
@@ -6,11 +6,37 @@ export const ImageUploadBox = styled.div`
   align-items: center;
   text-align: center;
 
-  width: 30%;
+  width: 50%;
   height: 20rem;
   border: 2px solid ${({ theme }) => theme.colors.line.blue};
-  border-radius: 10%;
+  border-radius: 5%;
   margin-bottom: 1.5rem;
+`;
+export const ScrollContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  width: 100%;
+  height: 100%;
+  overflow-x: auto; 
+  scroll-snap-type: x mandatory; 
+  
+  & > div {
+    flex: 0 0 80%;
+    height: 100%;
+    scroll-snap-align: center; 
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &::-webkit-scrollbar {
+    height: 8px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: ${({ theme }) => theme.colors.blue};
+    border-radius: 10%;
+  }
 `;
 
 export const ContentLinkUploadBox = styled.div`


### PR DESCRIPTION
### 구현내용
- 여러 이미지 파일을 업로드 가능
- 또한 미리보기에서 가로 스크롤바를 통해 다음 이미지를 보기 가능

### 확장가능성 부분 -> 이 부분에 대해서는 노션에 따로 적어두겠습니다!
- 이미지 선택 후  x 표시를 추가하여 이미지 삭제 기능
- 대표 이미지 선택화 ( 현재는 첫번째 이미지가 대표 이미지로 자동 선택됨)
- 여러개의 이미지 선택 시, 캐러셀로 이미지 넘기기 기능 ( 현재는 스크롤바로 이미지 넘기고 있음)