### PR TITLE
feat: 설명 글 작성 박스에 토글 가능한 textarea와 글자 수 카운터 추가

### DIFF
--- a/src/components/feedwriting/ContentWriting.tsx
+++ b/src/components/feedwriting/ContentWriting.tsx
@@ -1,14 +1,44 @@
+import { useState } from 'react';
 import { ColumnWrapper } from '@/components/feedwriting/Layout.style';
 import { Desc, TitleStyle } from '@/components/feedwriting/Title.style';
-import { ContentLinkUploadBox } from '@/components/feedwriting/UploadBox.style';
+import { ContentLinkUploadBox, TextArea, Counter } from '@/components/feedwriting/UploadBox.style';
 
 const ContentWriting = () => {
+  const [content, setContent] = useState('');
+  const [isActive, setIsActive] = useState(false); 
+  const maxLength = 200;
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setContent(e.target.value);
+  };
+
+  const handleBlur = () => {
+    if(content.trim()===''){
+      setIsActive(false);
+    }
+  };
+
   return (
     <ColumnWrapper>
       <TitleStyle>설명 글 작성하기(본문내용)</TitleStyle>
-      <ContentLinkUploadBox>
-        <Desc>게시물에 대한 이야기를 적어주세요.</Desc>
+      <ContentLinkUploadBox onClick={() => setIsActive(true)}>
+        {isActive ? (
+          <TextArea
+            value={content}
+            onChange={handleChange}
+            maxLength={maxLength}
+            onBlur = {handleBlur}
+            autoFocus 
+          />
+        ) : (
+          <Desc>게시물에 대한 이야기를 적어주세요.</Desc>
+        )}
       </ContentLinkUploadBox>
+      {isActive && (
+        <Counter>
+          {content.length} / {maxLength} 글자
+        </Counter>
+      )}
     </ColumnWrapper>
   );
 };

--- a/src/components/feedwriting/UploadBox.style.ts
+++ b/src/components/feedwriting/UploadBox.style.ts
@@ -25,3 +25,21 @@ export const ContentLinkUploadBox = styled.div`
   border-radius: 10%;
   margin-bottom: 1rem;
 `;
+
+export const TextArea = styled.textarea`
+  width: 90%;
+  height: 90%;
+  resize: none;
+  border: none;
+  outline: none;
+  font-size: 1rem;
+  font-family: inherit;
+  background: ${({theme})=>theme.colors.background.default}
+`;
+
+export const Counter = styled.div`
+  width: 60%;
+  text-align: right;
+  font-size: 0.9rem;
+  color: ${({ theme }) => theme.colors.text.black};
+`;


### PR DESCRIPTION
- 초기 상태에서는 안내 문구만 표시
- 박스 클릭 시 textarea 렌더링 및 자동 포커스
- 글자 수 카운터 추가 (최대 200자)
- blur 시 내용이 없으면 안내 문구로 복귀