### PR TITLE
chore: React Query 환경 세팅 및 qeuryKeys 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/babel-plugin": "^11.13.5",
         "@hookform/resolvers": "^5.2.1",
+        "@tanstack/react-query": "^5.90.2",
         "axios": "^1.12.0",
         "instagram-feed": "^1.0.4",
         "lucide-react": "^0.540.0",
@@ -1475,6 +1476,32 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@emotion/babel-plugin": "^11.13.5",
     "@hookform/resolvers": "^5.2.1",
+    "@tanstack/react-query": "^5.90.2",
     "axios": "^1.12.0",
     "instagram-feed": "^1.0.4",
     "lucide-react": "^0.540.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,22 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import App from './App.tsx';
 import { ThemeProvider } from 'styled-components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import App from './App.tsx';
 import { theme } from '@/styles/theme';
 import { GlobalStyle } from '@/styles/GlobalStyle';
 
+
+const queryClient = new QueryClient()
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <App />
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <App />
+      </ThemeProvider>
+    </QueryClientProvider>
   </StrictMode>
-);
+)

--- a/src/utils/queryKeys.ts
+++ b/src/utils/queryKeys.ts
@@ -1,0 +1,5 @@
+export const QUERY_KEYS = {
+  login: ['auth', 'login'] as const,
+  signup: ['auth', 'signup'] as const,
+  user: ['auth', 'user'] as const, 
+}


### PR DESCRIPTION
- `main.tsx` → **React Query를 앱 전체에서 쓸 수 있는 환경 세팅**
- `queryKeys.ts` → **로그인/회원가입/유저 API 캐싱 키를 일관되게 관리**


#### 현재 main.tsx에서 추후 필요할 때 옵션 확장
- api 요청이 많아지고
- 캐싱 전략 필요할 때
- 공통 에러 처리 필요할 때

#### queryKey를 중앙에서 관리
- 예 : useQuery ({queryKey: ['auth','user'],queryFn : fetchUser})