### PR TITLE
Feat/auth hooks,pages refactor

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,16 +1,13 @@
 import axiosInstance from './axiosInstance';
+import type { LoginValues } from '@/types/LoginZodSchema'
+import type { Step2Values } from '@/types/SignupZodSchema'
 
-export const signup = async (data: { email: string; password: string; name: string }) => {
-  const res = await axiosInstance.post('/api/auth/signup', data);
-  return res.data;
-};
+export const signup = async (data: Step2Values) => {
+  const res = await axiosInstance.post('/api/auth/signup', data)
+  return res.data
+}
 
-export const login = async (data: { email: string; password: string }) => {
-  const res = await axiosInstance.post('/api/auth/login', data);
-
-  if (res.data?.accessToken) {
-    localStorage.setItem('accessToken', res.data.accessToken);
-  }
-
-  return res.data;
-};
+export const login = async (data: LoginValues) => {
+  const res = await axiosInstance.post('/api/auth/login', data)
+  return res.data
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,8 +1,9 @@
 import axiosInstance from './axiosInstance';
 import type { LoginValues } from '@/types/LoginZodSchema'
-import type { Step2Values } from '@/types/SignupZodSchema'
+import type { SignupRequest } from '@/types/AuthTypes'
 
-export const signup = async (data: Step2Values) => {
+
+export const signup = async (data: SignupRequest) => {
   const res = await axiosInstance.post('/api/auth/signup', data)
   return res.data
 }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,6 +1,35 @@
 import { useContext } from 'react';
 import { AuthContext } from '@/contexts/AuthContext';
 
+import { useMutation } from '@tanstack/react-query'
+import { login, signup } from '@/api/auth'
+import { QUERY_KEYS } from '@/utils/queryKeys'
+
+import type { LoginValues } from '@/types/LoginZodSchema'
+import type { Step2Values } from '@/types/SignupZodSchema'
+
+export const useLogin = () => {
+  return useMutation({
+    mutationKey: QUERY_KEYS.login,
+    mutationFn: (data: LoginValues) => login(data),
+    onSuccess: (data) => {
+      if (data.accessToken) {
+        localStorage.setItem('accessToken', data.accessToken)
+      }
+    },
+  })
+}
+
+export const useSignup = () => {
+  return useMutation({
+    mutationKey: QUERY_KEYS.signup,
+    mutationFn: (data: Step2Values) => signup(data),
+    onSuccess: () => {
+      console.log('✅ 회원가입 성공')
+    },
+  })
+}
+
 export function useAuth() {
   const context = useContext(AuthContext);
   if (!context) {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,12 +1,13 @@
 import { useContext } from 'react';
 import { AuthContext } from '@/contexts/AuthContext';
 
-import { useMutation } from '@tanstack/react-query'
-import { login, signup } from '@/api/auth'
-import { QUERY_KEYS } from '@/utils/queryKeys'
+import { useMutation } from '@tanstack/react-query';
+import { login, signup } from '@/api/auth';
+import { QUERY_KEYS } from '@/utils/queryKeys';
 
-import type { LoginValues } from '@/types/LoginZodSchema'
-import type { SignupRequest } from '@/types/AuthTypes'
+import type { LoginValues } from '@/types/LoginZodSchema';
+import type { SignupRequest } from '@/types/AuthTypes';
+import type { Step2Values } from '@/types/SignupZodSchema';
 
 export const useLogin = () => {
   return useMutation({
@@ -14,21 +15,34 @@ export const useLogin = () => {
     mutationFn: (data: LoginValues) => login(data),
     onSuccess: (data) => {
       if (data.accessToken) {
-        localStorage.setItem('accessToken', data.accessToken)
+        localStorage.setItem('accessToken', data.accessToken);
       }
     },
-  })
-}
+  });
+};
 
 export const useSignup = () => {
   return useMutation({
     mutationKey: QUERY_KEYS.signup,
-    mutationFn: (data: SignupRequest) => signup(data),
-    onSuccess: () => {
-      console.log('✅ 회원가입 성공')
+    mutationFn: (data: Step2Values) => {
+      const step1 = JSON.parse(sessionStorage.getItem('signupStep1') || '{}');
+
+      const finalData: SignupRequest = {
+        email: data.email,
+        password: data.password,
+        name: step1.name,
+        birthDate: step1.birthDate,
+        gender: step1.gender?.toUpperCase(),
+        phoneNumber: step1.telephone,
+      };
+
+      return signup(finalData);
     },
-  })
-}
+    onSuccess: () => {
+      console.log('✅ 회원가입 성공');
+    },
+  });
+};
 
 export function useAuth() {
   const context = useContext(AuthContext);

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -6,7 +6,7 @@ import { login, signup } from '@/api/auth'
 import { QUERY_KEYS } from '@/utils/queryKeys'
 
 import type { LoginValues } from '@/types/LoginZodSchema'
-import type { Step2Values } from '@/types/SignupZodSchema'
+import type { SignupRequest } from '@/types/AuthTypes'
 
 export const useLogin = () => {
   return useMutation({
@@ -23,7 +23,7 @@ export const useLogin = () => {
 export const useSignup = () => {
   return useMutation({
     mutationKey: QUERY_KEYS.signup,
-    mutationFn: (data: Step2Values) => signup(data),
+    mutationFn: (data: SignupRequest) => signup(data),
     onSuccess: () => {
       console.log('✅ 회원가입 성공')
     },

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { login as loginApi } from '@/api/auth';
-import { useAuth } from '@/hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
+
 import { loginSchema, type LoginValues } from '@/types/LoginZodSchema';
+import { useLogin } from '@/hooks/useAuth';
 
 import {
   LoginContainer,
@@ -40,23 +40,20 @@ export default function LoginForm() {
   });
 
   const [showPassword, setShowPassword] = useState(false);
-
-  const { login } = useAuth();
   const navigate = useNavigate();
 
-  const onSubmit = async (data: LoginValues) => {
-    try {
-      const res = await loginApi(data);
-      console.log('로그인 성공:', res);
+  const { mutate: loginMutate, isPending, isError } = useLogin();
 
-      login(res.accessToken, res.refreshToken);
-
-      alert('로그인 성공!');
-      navigate('/');
-    } catch (err) {
-      console.error('로그인 실패:', err);
-      alert('이메일/비밀번호를 확인해주세요.');
-    }
+  const onSubmit = (data: LoginValues) => {
+    loginMutate(data, {
+      onSuccess: () => {
+        alert('로그인 성공!');
+        navigate('/');
+      },
+      onError: () => {
+        alert('이메일/비밀번호를 확인해주세요.');
+      },
+    });
   };
 
   return (
@@ -90,8 +87,10 @@ export default function LoginForm() {
           </InputWrapper>
           {errors.password && <ErrorMessage>{errors.password.message}</ErrorMessage>}
 
-          <SubmitButton type="submit" disabled={!isValid}>
-            로그인
+          {isError && <ErrorMessage>로그인 실패! 다시 시도해주세요.</ErrorMessage>}
+
+          <SubmitButton type="submit" disabled={!isValid || isPending}>
+            {isPending ? '로그인 중...' : '로그인'}
           </SubmitButton>
 
           <Line />

--- a/src/pages/SignupAccount.tsx
+++ b/src/pages/SignupAccount.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
-
-import { signup } from '@/api/auth';
 import { zodResolver } from '@hookform/resolvers/zod';
+
 import { step2Schema, type Step2Values } from '@/types/SignupZodSchema';
+import { useSignup } from '@/hooks/useAuth';
 
 import {
   SignupContainer,
@@ -39,29 +39,29 @@ export default function SignupStep2() {
 
   const navigate = useNavigate();
 
-  const onSubmit = async (data: Step2Values) => {
-    try {
-      const step1 = JSON.parse(sessionStorage.getItem('signupStep1') || '{}');
+  const { mutate: signupMutate, isPending, isError } = useSignup();
 
-      const finalData = {
-        email: data.email,
-        password: data.password,
-        name: step1.name,
-        birthDate: step1.birthDate,
-        gender: step1.gender.toUpperCase(),
-        phoneNumber: step1.telephone,
-      };
+  const onSubmit = (data: Step2Values) => {
+    const step1 = JSON.parse(sessionStorage.getItem('signupStep1') || '{}');
 
-      const res = await signup(finalData);
-      if (res.success) {
+    const finalData = {
+      email: data.email,
+      password: data.password,
+      name: step1.name,
+      birthDate: step1.birthDate,
+      gender: step1.gender?.toUpperCase(),
+      phoneNumber: step1.telephone,
+    };
+
+    signupMutate(finalData, {
+      onSuccess: () => {
         alert('회원가입 성공! 로그인 페이지로 이동합니다.');
-      }
-
-      navigate('/login');
-    } catch (err) {
-      console.error('회원가입 실패:', err);
-      alert('회원가입에 실패했습니다.');
-    }
+        navigate('/login');
+      },
+      onError: () => {
+        alert('회원가입에 실패했습니다. 다시 시도해주세요.');
+      },
+    });
   };
 
   return (
@@ -121,9 +121,11 @@ export default function SignupStep2() {
               <ErrorMessage>{errors.confirmPassword.message}</ErrorMessage>
             )}
           </FormGroup>
+          
+          {isError && <ErrorMessage>회원가입 요청 중 오류가 발생했습니다.</ErrorMessage>}
 
-          <NextButton type="submit" disabled={!isValid}>
-            회원가입
+          <NextButton type="submit" disabled={!isValid || isPending}>
+            {isPending ? '회원가입 중...' : '회원가입'}
           </NextButton>
         </FormWrapper>
       </Container>

--- a/src/pages/SignupAccount.tsx
+++ b/src/pages/SignupAccount.tsx
@@ -42,18 +42,7 @@ export default function SignupStep2() {
   const { mutate: signupMutate, isPending, isError } = useSignup();
 
   const onSubmit = (data: Step2Values) => {
-    const step1 = JSON.parse(sessionStorage.getItem('signupStep1') || '{}');
-
-    const finalData = {
-      email: data.email,
-      password: data.password,
-      name: step1.name,
-      birthDate: step1.birthDate,
-      gender: step1.gender?.toUpperCase(),
-      phoneNumber: step1.telephone,
-    };
-
-    signupMutate(finalData, {
+    signupMutate(data, {
       onSuccess: () => {
         alert('회원가입 성공! 로그인 페이지로 이동합니다.');
         navigate('/login');
@@ -121,7 +110,7 @@ export default function SignupStep2() {
               <ErrorMessage>{errors.confirmPassword.message}</ErrorMessage>
             )}
           </FormGroup>
-          
+
           {isError && <ErrorMessage>회원가입 요청 중 오류가 발생했습니다.</ErrorMessage>}
 
           <NextButton type="submit" disabled={!isValid || isPending}>

--- a/src/types/AuthTypes.ts
+++ b/src/types/AuthTypes.ts
@@ -1,0 +1,8 @@
+export interface SignupRequest {
+  email: string
+  password: string
+  name: string
+  birthDate: string
+  gender: string
+  phoneNumber: string
+}


### PR DESCRIPTION
#### 로그인/회원가입 훅 리팩토링
- hooks/useAuth.ts → useLogin, useSignup을 useMutation 기반으로 작성

#### 페이지 리팩토링
-   `loginApi` 직접 호출 → `useLogin` 훅으로 교체 완료
- `try/catch` 제거, `mutate` + `onSuccess`/`onError` 사용
-  로딩/에러 상태 → `isPending`, `isError`로 교체

- 기존 `signup` 직접 호출 제거
-   `useSignup` 훅으로 교체 완료
-   `try/catch` 제거, `mutate` + `onSuccess`/`onError` 사용
-  로딩/에러 상태 → `isPending`, `isError`로 교체

#### [계속 오류 발생했던 부분]
타입 불일치 문제 → SignupRequest 타입을 정의하고 auth.ts에서 적용
