### PR TITLE
refactor-jaewon: 8주차 코드리뷰 / 댓글/답글 입력 컴포넌트 일관성 개선 및 매직 넘버 상수화

### DIFF
--- a/src/components/comment/CommentInput.tsx
+++ b/src/components/comment/CommentInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Send } from 'lucide-react';
 import {
   CommentInputSection,
@@ -7,23 +7,26 @@ import {
 } from './CommentSection.styles';
 
 interface CommentInputProps {
-  value: string;
-  onChange: (value: string) => void;
-  onSubmit: (e: React.FormEvent) => void;
+  onSubmit: (content: string) => void;
   placeholder?: string;
 }
 
-const CommentInput: React.FC<CommentInputProps> = ({
-  value,
-  onChange,
-  onSubmit,
-  placeholder = '댓글 작성하기',
-}) => {
+const CommentInput: React.FC<CommentInputProps> = ({ onSubmit, placeholder = '댓글 작성하기' }) => {
+  const [content, setContent] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (content.trim()) {
+      onSubmit(content.trim());
+      setContent('');
+    }
+  };
+
   return (
-    <CommentInputSection onSubmit={onSubmit}>
+    <CommentInputSection onSubmit={handleSubmit}>
       <StyledCommentInput
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
         placeholder={placeholder}
       />
       <CommentSubmitButton type="submit">

--- a/src/components/comment/CommentInput.tsx
+++ b/src/components/comment/CommentInput.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Send } from 'lucide-react';
+import { COMMENT_CONSTANTS } from '@/constants/feed';
 import {
   CommentInputSection,
   CommentInput as StyledCommentInput,
@@ -11,7 +12,7 @@ interface CommentInputProps {
   placeholder?: string;
 }
 
-const CommentInput: React.FC<CommentInputProps> = ({ onSubmit, placeholder = '댓글 작성하기' }) => {
+const CommentInput: React.FC<CommentInputProps> = ({ onSubmit, placeholder = COMMENT_CONSTANTS.COMMENT_PLACEHOLDER }) => {
   const [content, setContent] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/src/components/comment/CommentSection.tsx
+++ b/src/components/comment/CommentSection.tsx
@@ -28,11 +28,8 @@ const CommentSection: React.FC<CommentSectionProps> = ({
   onLikeReply,
 }) => {
   const {
-    newComment,
     replyingTo,
     showReplies,
-    setNewComment,
-    handleSubmitComment,
     handleLikeComment,
     handleLikeReply,
     toggleReplies,
@@ -44,6 +41,10 @@ const CommentSection: React.FC<CommentSectionProps> = ({
     onLikeComment,
     onLikeReply,
   });
+
+  const handleAddComment = (content: string) => {
+    onAddComment({ feedId, content });
+  };
 
   const handleAddReply = (commentId: number, content: string) => {
     onAddReply({ commentId, content });
@@ -57,9 +58,7 @@ const CommentSection: React.FC<CommentSectionProps> = ({
 
       {/* 댓글 작성 */}
       <CommentInput
-        value={newComment}
-        onChange={setNewComment}
-        onSubmit={handleSubmitComment}
+        onSubmit={handleAddComment}
         placeholder="댓글 작성하기"
       />
 

--- a/src/components/comment/ReplyInput.tsx
+++ b/src/components/comment/ReplyInput.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Send } from 'lucide-react';
+import { COMMENT_CONSTANTS } from '@/constants/feed';
 import {
   ReplyInputSection,
   ReplyInput as StyledReplyInput,
@@ -11,7 +12,7 @@ interface ReplyInputProps {
   placeholder?: string;
 }
 
-const ReplyInput: React.FC<ReplyInputProps> = ({ onSubmit, placeholder = '답글 작성하기' }) => {
+const ReplyInput: React.FC<ReplyInputProps> = ({ onSubmit, placeholder = COMMENT_CONSTANTS.REPLY_PLACEHOLDER }) => {
   const [content, setContent] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/src/components/feed/FeedDetailSection.tsx
+++ b/src/components/feed/FeedDetailSection.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import type { FeedDetail } from '@/types/Feed';
+import { FEED_CONSTANTS } from '@/constants/feed';
 import {
   FeedDetailContainer,
   UserProfile,
@@ -63,7 +64,7 @@ const FeedDetailSection: React.FC<FeedDetailSectionProps> = ({ feed, onLike, onB
     );
   };
 
-  const displayedProducts = showAllProducts ? feed.products : feed.products.slice(0, 3);
+  const displayedProducts = showAllProducts ? feed.products : feed.products.slice(0, FEED_CONSTANTS.INITIAL_PRODUCT_DISPLAY_COUNT);
 
   return (
     <FeedDetailContainer>
@@ -142,7 +143,7 @@ const FeedDetailSection: React.FC<FeedDetailSectionProps> = ({ feed, onLike, onB
               <ProductLink>링크로 이동</ProductLink>
             </ProductItem>
           ))}
-          {feed.products.length > 3 && !showAllProducts && (
+          {feed.products.length > FEED_CONSTANTS.INITIAL_PRODUCT_DISPLAY_COUNT && !showAllProducts && (
             <MoreProductsButton onClick={() => setShowAllProducts(true)}>
               취미 팩 더보기 ↓
             </MoreProductsButton>

--- a/src/constants/feed.ts
+++ b/src/constants/feed.ts
@@ -1,0 +1,5 @@
+// 피드 상품 노출 개수 관련 상수
+export const FEED_CONSTANTS = {
+  // 초기 상품 노출 개수 (더보기 버튼 표시 기준)
+  INITIAL_PRODUCT_DISPLAY_COUNT: 3,
+} as const;

--- a/src/constants/feed.ts
+++ b/src/constants/feed.ts
@@ -1,5 +1,10 @@
-// 피드 상품 노출 개수 관련 상수
 export const FEED_CONSTANTS = {
   // 초기 상품 노출 개수 (더보기 버튼 표시 기준)
   INITIAL_PRODUCT_DISPLAY_COUNT: 3,
+} as const;
+
+
+export const COMMENT_CONSTANTS = {
+  COMMENT_PLACEHOLDER: '댓글 작성하기',
+  REPLY_PLACEHOLDER: '답글 작성하기',
 } as const;

--- a/src/hooks/useCommentActions.ts
+++ b/src/hooks/useCommentActions.ts
@@ -10,33 +10,16 @@ interface UseCommentActionsProps {
 }
 
 export const useCommentActions = ({
-  feedId,
-  onAddComment,
   onAddReply,
   onLikeComment,
   onLikeReply,
 }: UseCommentActionsProps) => {
-  // 댓글 작성 상태
-  const [newComment, setNewComment] = useState('');
-
   // 답글 작성 상태
   const [replyingTo, setReplyingTo] = useState<number | null>(null);
   const [replyContent, setReplyContent] = useState('');
 
   // 답글 표시 상태
   const [showReplies, setShowReplies] = useState<{ [key: number]: boolean }>({});
-
-  // 댓글 제출 핸들러
-  const handleSubmitComment = useCallback(
-    (e: React.FormEvent) => {
-      e.preventDefault();
-      if (newComment.trim()) {
-        onAddComment({ feedId, content: newComment.trim() });
-        setNewComment('');
-      }
-    },
-    [feedId, newComment, onAddComment]
-  );
 
   // 답글 제출 핸들러
   const handleSubmitReply = useCallback(
@@ -87,17 +70,14 @@ export const useCommentActions = ({
 
   return {
     // 상태
-    newComment,
     replyingTo,
     replyContent,
     showReplies,
 
     // 상태 변경 함수
-    setNewComment,
     setReplyContent,
 
     // 이벤트 핸들러
-    handleSubmitComment,
     handleSubmitReply,
     handleLikeComment,
     handleLikeReply,


### PR DESCRIPTION
### 컴포넌트 일관성 개선
- `CommentInput`을 `ReplyInput`과 동일한 패턴으로 통일
  - 제어 컴포넌트에서 비제어 컴포넌트로 변경

### 매직 넘버 상수화
- 피드 상품 노출 개수 상수화
  - `FeedDetailSection.tsx`에서 매직 넘버 제거

- 댓글 플레이스홀더 상수화
  - `COMMENT_CONSTANTS.COMMENT_PLACEHOLDER: '댓글 작성하기'` 추가
  - `COMMENT_CONSTANTS.REPLY_PLACEHOLDER: '답글 작성하기'` 추가
  - `CommentInput.tsx`, `ReplyInput.tsx`에서 매직 스트링 제거

### 코드 정리
- CommentSection 단순화
- useCommentActions 훅 정리
  - `newComment` 관련 코드 제거
  - 답글 관련 로직만 유지