### PR TITLE
fix: presigned URL 발급은 POST, S3업로드는 PUT

### DIFF
--- a/src/api/s3Api.ts
+++ b/src/api/s3Api.ts
@@ -1,6 +1,6 @@
 import axiosInstance from '@/api/axiosInstance';
 import { ensureCsrfToken } from '@/utils/csrf';
-import  { AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 
 type PresignedUrlRequest = {
   files: {
@@ -9,11 +9,13 @@ type PresignedUrlRequest = {
   }[];
 };
 
+// POST presigned URL 구조 대응
 export type PresignedUrlResponse = {
   presignedUrl: string;
   fileUrl: string;
 }[];
 
+// ==================== Presigned URL 발급 ====================
 export const getPresignedUrls = async (
   dirName: string,
   files: File[]
@@ -39,23 +41,21 @@ export const getPresignedUrls = async (
 
     return data;
   } catch (error) {
- 
     if (error instanceof AxiosError) {
       console.error('[Presigned URL 요청 실패]', error.response?.data || error.message);
       throw error;
     }
-
     console.error('[Presigned URL 요청 실패 - Unknown]', error);
     throw error;
   }
 };
-
 export const uploadToS3 = async (presignedUrl: string, file: File): Promise<void> => {
   try {
     const res = await fetch(presignedUrl, {
       method: 'PUT',
       headers: {
         'Content-Type': file.type,
+        'x-amz-acl': 'public-read',
       },
       body: file,
     });

--- a/src/components/pack_feed_writing/ThumbnailImage.tsx
+++ b/src/components/pack_feed_writing/ThumbnailImage.tsx
@@ -10,7 +10,7 @@ type ThumbnailImageProps = {
 const ThumbnailImage = ({ onChange }: ThumbnailImageProps) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [previews, setPreviews] = useState<string[]>([]);
-  const { mutateAsync: uploadImages, isPending } = useUploadImages(); 
+  const { mutateAsync: uploadImages, isPending } = useUploadImages();
 
   const handleBoxClick = () => {
     if (!isPending) fileInputRef.current?.click();
@@ -25,14 +25,14 @@ const ThumbnailImage = ({ onChange }: ThumbnailImageProps) => {
     setPreviews(urls);
 
     try {
-
       const uploadedUrls = await uploadImages(fileArray);
-      if (uploadedUrls.length > 0) onChange(uploadedUrls[0]); 
+      if (uploadedUrls.length > 0) onChange(uploadedUrls[0]);
     } catch (err) {
       console.error('이미지 업로드 실패:', err);
     }
 
-    e.currentTarget.value = '';
+    if (e.currentTarget) e.currentTarget.value = '';
+
   };
 
   useEffect(() => {

--- a/src/hooks/useUploadImages.ts
+++ b/src/hooks/useUploadImages.ts
@@ -2,19 +2,20 @@ import { useMutation } from '@tanstack/react-query';
 import { getPresignedUrls, uploadToS3 } from '@/api/s3Api';
 import { AxiosError } from 'axios';
 
+// 여러 이미지 업로드 후 S3 URL 반환
 export const useUploadImages = () => {
-  return useMutation<
-    string[], 
-    AxiosError<{ message?: string }>,
-    File[] 
-  >({
+  return useMutation<string[], AxiosError<{ message?: string }>, File[]>({
     mutationFn: async (files: File[]) => {
+      // Presigned URL 리스트 발급
       const presignedList = await getPresignedUrls('feed', files);
 
-      await Promise.all(
-        presignedList.map((item, idx) => uploadToS3(item.presignedUrl, files[idx]))
-      );
+  await Promise.all(
+  presignedList.map((item, idx) =>
+    uploadToS3(item.presignedUrl, files[idx])
+  )
+);
 
+      // 업로드 후 최종 S3 fileUrl 배열 반환
       return presignedList.map((item) => item.fileUrl);
     },
   });


### PR DESCRIPTION
#### s3 이미지 업로드 흐름
[1] 사용자가 파일 선택
 ↓
[2] 프론트에서 presigned URL 요청 (POST /api/s3/presigned-urls)
 ↓
[3] presignedUrl, fileUrl 응답 수신
 ↓
[4] presignedUrl 로 S3에 직접 PUT 업로드
 ↓
[5] S3 업로드 완료 후 fileUrl 반환
 ↓
[6] 부모 컴포넌트로 대표 이미지 URL 전달

- POST 요청을 명시적으로 서술함으로써, 실제 네트워크 트랜잭션의 흐름을 더 명확히 표현. 
-> 전에는 암묵적(함수 내부에서 일어남)
- “백엔드가 presigned URL을 생성해 주는 역할”과 “S3로 직접 PUT 업로드하는 역할”이 분리되어 보이도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented runtime validation for file upload responses to prevent invalid data processing
  * Added null-safety checks in file input handling to prevent potential crashes

* **Improvements**
  * Enhanced file accessibility settings for uploaded content
  * Strengthened type safety for image upload operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->