### PR TITLE
상품이미지 blob: URL 전송 오류 수정

### DIFF
--- a/src/components/pack_feed_writing/LinkWriting.tsx
+++ b/src/components/pack_feed_writing/LinkWriting.tsx
@@ -11,12 +11,15 @@ import {
 import LinkModal from '@/components/pack_feed_writing/LinkModal';
 import type { ProductForm } from '@/types/LinkWriteForm';
 import type { WriteProduct } from '@/types/Product';
+import { useUploadImages } from '@/hooks/useUploadImages';
 
 type LinkWritingProps = {
   onChange: (items: WriteProduct[]) => void;
 };
+
 const LinkWriting = ({ onChange }: LinkWritingProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
 
   const [formData, setFormData] = useState<ProductForm>({
     products: [
@@ -26,22 +29,42 @@ const LinkWriting = ({ onChange }: LinkWritingProps) => {
 
   const [submittedProducts, setSubmittedProducts] = useState<WriteProduct[]>([]);
 
-  const handleSubmit = (data: ProductForm) => {
-    setFormData(data);
+  const { mutateAsync: uploadImages } = useUploadImages('products');
 
-    const productsWithPreview: WriteProduct[] = data.products.map((p) => {
-      const newImageUrl = p.imageFile ? URL.createObjectURL(p.imageFile) : (p.imageUrl ?? '');
-      return {
-        name: p.name,
-        linkUrl: p.linkUrl,
-        description: p.description ?? '',
-        imageUrl: newImageUrl,
-      };
-    });
+  const handleSubmit = async (data: ProductForm) => {
+    setFormData(data); 
+    setIsUploading(true); 
+    setIsOpen(false); 
 
-    setSubmittedProducts(productsWithPreview);
-    onChange(productsWithPreview);
-    setIsOpen(false);
+    try {
+      const productsWithRealUrls: WriteProduct[] = await Promise.all(
+        data.products.map(async (p) => {
+          let finalImageUrl: string;
+
+          if (p.imageFile) {
+            const uploadedUrls = await uploadImages([p.imageFile]);
+            finalImageUrl = uploadedUrls[0];
+          } else {
+            finalImageUrl = p.imageUrl ?? '';
+          }
+
+          return {
+            name: p.name,
+            linkUrl: p.linkUrl,
+            description: p.description ?? '',
+            imageUrl: finalImageUrl, 
+          };
+        }),
+      );
+
+      setSubmittedProducts(productsWithRealUrls);
+      onChange(productsWithRealUrls);
+    } catch (err) {
+      console.error('상품 이미지 업로드 실패:', err);
+      alert('상품 이미지 업로드 중 오류가 발생했습니다.');
+    } finally {
+      setIsUploading(false); 
+    }
   };
 
   useEffect(() => {
@@ -61,8 +84,13 @@ const LinkWriting = ({ onChange }: LinkWritingProps) => {
   return (
     <ColumnWrapper>
       <TitleStyle>상품 링크 작성하기</TitleStyle>
-      <LinkUploadBox $hasProducts={submittedProducts.length > 0} onClick={() => setIsOpen(true)}>
-        {submittedProducts.length === 0 ? (
+      <LinkUploadBox
+        $hasProducts={submittedProducts.length > 0}
+        onClick={() => !isUploading && setIsOpen(true)}
+      >
+        {isUploading ? (
+          <Desc>상품 이미지를 업로드 중입니다...</Desc>
+        ) : submittedProducts.length === 0 ? (
           <Desc>
             정보 공유 목적시 링크를 꼭 작성해 주세요. <br /> 작성을 원하실 경우 클릭해 주세요.
           </Desc>
@@ -83,6 +111,7 @@ const LinkWriting = ({ onChange }: LinkWritingProps) => {
         onClose={() => setIsOpen(false)}
         onSubmit={handleSubmit}
         defaultValues={formData}
+
       />
     </ColumnWrapper>
   );

--- a/src/components/pack_feed_writing/LinkWriting.tsx
+++ b/src/components/pack_feed_writing/LinkWriting.tsx
@@ -32,9 +32,9 @@ const LinkWriting = ({ onChange }: LinkWritingProps) => {
   const { mutateAsync: uploadImages } = useUploadImages('products');
 
   const handleSubmit = async (data: ProductForm) => {
-    setFormData(data); 
-    setIsUploading(true); 
-    setIsOpen(false); 
+    setFormData(data);
+    setIsUploading(true);
+    setIsOpen(false);
 
     try {
       const productsWithRealUrls: WriteProduct[] = await Promise.all(
@@ -52,18 +52,26 @@ const LinkWriting = ({ onChange }: LinkWritingProps) => {
             name: p.name,
             linkUrl: p.linkUrl,
             description: p.description ?? '',
-            imageUrl: finalImageUrl, 
+            imageUrl: finalImageUrl,
           };
-        }),
+        })
       );
 
       setSubmittedProducts(productsWithRealUrls);
+      setFormData({
+        products: data.products.map((product, idx) => ({
+          ...product,
+          imageFile: undefined, 
+          imageUrl: productsWithRealUrls[idx].imageUrl, 
+        })),
+      });
+
       onChange(productsWithRealUrls);
     } catch (err) {
       console.error('상품 이미지 업로드 실패:', err);
       alert('상품 이미지 업로드 중 오류가 발생했습니다.');
     } finally {
-      setIsUploading(false); 
+      setIsUploading(false);
     }
   };
 
@@ -111,7 +119,6 @@ const LinkWriting = ({ onChange }: LinkWritingProps) => {
         onClose={() => setIsOpen(false)}
         onSubmit={handleSubmit}
         defaultValues={formData}
-
       />
     </ColumnWrapper>
   );


### PR DESCRIPTION
blob: URL이 폼 제출 시 서버로 전송되어 "유효한 URL 형식이 아닙니다" (`400 Bad Request`) 오류가 발생

`useUploadImages` 훅을 사용해 모달 제출 시점에 이미지를 서버에 먼저 업로드하고, 반환된 실제 URL을
상태에 저장하도록 로직을 변경하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Product images now upload to and use persistent server-provided URLs instead of temporary client-side links.
  * Improved error handling with clear notifications when uploads fail; upload state is reliably reset.

* **User Experience**
  * Loading indicator shown during image uploads.
  * Modal/upload controls are locked while uploads are in progress to prevent accidental interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->