### PR TITLE
Fix/detailpage-owari: 스타터팩 디테일 페이지 및 피드 UI/UX 개선

### DIFF
--- a/src/api/feedApi.ts
+++ b/src/api/feedApi.ts
@@ -1,4 +1,5 @@
 import axiosInstance from './axiosInstance';
+import { ensureCsrfToken } from '@/utils/csrf';
 import { FEED_API_CONSTANTS } from '@/constants/feed';
 import type {
   FeedPost,
@@ -87,6 +88,7 @@ export const deleteFeed = async (id: number): Promise<void> => {
 // 피드 좋아요 토글
 export const toggleFeedLike = async (id: number): Promise<LikePostResponse> => {
   try {
+    await ensureCsrfToken();
     const response = await axiosInstance.post<LikePostResponse>(`/api/feeds/${id}/like`);
     return response.data;
   } catch (error) {
@@ -100,6 +102,7 @@ export const toggleFeedBookmark = async (
   id: number
 ): Promise<{ isBookmarked: boolean; bookmarkCount: number }> => {
   try {
+    await ensureCsrfToken();
     const response = await axiosInstance.post<{ isBookmarked: boolean; bookmarkCount: number }>(
       `/api/feeds/${id}/bookmark`
     );
@@ -169,6 +172,7 @@ export const fetchComments = async (
 // parentId가 있으면 대댓글, 없으면 일반 댓글
 export const createComment = async (data: CreateCommentRequest): Promise<Comment> => {
   try {
+    await ensureCsrfToken();
     const requestBody: { content: string; parentId?: number | null } = {
       content: data.content,
     };
@@ -194,6 +198,7 @@ export const updateComment = async (
   data: { content: string }
 ): Promise<Comment> => {
   try {
+    await ensureCsrfToken();
     const response = await axiosInstance.put<Comment>(`/api/feeds/comments/${commentId}`, data);
     return response.data;
   } catch (error) {
@@ -205,6 +210,7 @@ export const updateComment = async (
 // 댓글 삭제
 export const deleteComment = async (commentId: number): Promise<void> => {
   try {
+    await ensureCsrfToken();
     await axiosInstance.delete(`/api/feeds/comments/${commentId}`);
   } catch (error) {
     console.error(`Failed to delete comment ${commentId}:`, error);

--- a/src/api/starterPackApi.ts
+++ b/src/api/starterPackApi.ts
@@ -1,4 +1,5 @@
 import axiosInstance from './axiosInstance';
+import { ensureCsrfToken } from '@/utils/csrf';
 import type {
   StarterPack,
   StarterPackResponse,
@@ -96,6 +97,7 @@ export const deleteStarterPack = async (id: number): Promise<void> => {
 // 스타터팩 좋아요 토글
 export const toggleStarterPackLike = async (id: number): Promise<LikeStarterPackResponse> => {
   try {
+    await ensureCsrfToken();
     const response = await axiosInstance.post<LikeStarterPackResponse>(
       `/api/starterPack/packs/${id}/like`
     );
@@ -111,6 +113,7 @@ export const toggleStarterPackBookmark = async (
   id: number
 ): Promise<BookmarkStarterPackResponse> => {
   try {
+    await ensureCsrfToken();
     const response = await axiosInstance.post<BookmarkStarterPackResponse>(
       `/api/starterPack/packs/${id}/bookmark`
     );
@@ -187,6 +190,7 @@ export const createPackComment = async (
   parentId?: number | null
 ): Promise<PackCommentResponse> => {
   try {
+    await ensureCsrfToken();
     const requestBody: { content: string; parentId?: number | null } = {
       content,
     };
@@ -212,6 +216,7 @@ export const updatePackComment = async (
   content: string
 ): Promise<PackCommentResponse> => {
   try {
+    await ensureCsrfToken();
     const response = await axiosInstance.put<PackCommentResponse>(
       `/api/starterPack/comments/${commentId}`,
       {
@@ -228,6 +233,7 @@ export const updatePackComment = async (
 // 스타터팩 댓글 삭제
 export const deletePackComment = async (commentId: number): Promise<void> => {
   try {
+    await ensureCsrfToken();
     await axiosInstance.delete(`/api/starterPack/comments/${commentId}`);
   } catch (error) {
     console.error(`Failed to delete comment ${commentId}:`, error);

--- a/src/components/feed/FeedDetailSection.styles.ts
+++ b/src/components/feed/FeedDetailSection.styles.ts
@@ -46,7 +46,7 @@ export const UserBio = styled.p`
 
 export const PostContent = styled.div`
   font-size: 1rem;
-  line-height: 1.5;
+  line-height: 1.25;
   color: #333;
   margin-bottom: 0.5rem;
   white-space: pre-line;

--- a/src/components/feed/FeedDetailSection.tsx
+++ b/src/components/feed/FeedDetailSection.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Heart, MessageCircle, Bookmark } from 'lucide-react';
 import type { FeedDetail } from '@/types/Feed';
 import { tokens } from '@/styles/tokens';
+import { formatFeedDate } from '@/utils/date';
 import {
   FeedDetailContainer,
   UserProfile,
@@ -79,7 +80,7 @@ const FeedDetailSection: React.FC<FeedDetailSectionProps> = ({ feed, onLike, onB
 
       {/* 본문 내용 */}
       <PostContent>{feed.description}</PostContent>
-      <PostDate>{feed.createdAt}</PostDate>
+      <PostDate>{formatFeedDate(feed.createdAt)}</PostDate>
 
       {/* 이미지 캐러셀 */}
       {images.length > 0 && (

--- a/src/components/feed/FeedInfoSection.styles.ts
+++ b/src/components/feed/FeedInfoSection.styles.ts
@@ -47,7 +47,7 @@ export const UserBio = styled.p`
 
 export const PostContent = styled.div`
   font-size: 1rem;
-  line-height: 1.5;
+  line-height: 1.25;
   color: ${tokens.colors.text.black};
   margin-bottom: 0.5rem;
   white-space: pre-line;

--- a/src/components/feed/FeedInfoSection.tsx
+++ b/src/components/feed/FeedInfoSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { FeedDetail } from '@/types/Feed';
+import { formatFeedDate } from '@/utils/date';
 import {
   InfoContainer,
   UserProfile,
@@ -29,7 +30,7 @@ const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({ feed }) => {
 
       {/* 본문 내용 */}
       <PostContent>{feed.description}</PostContent>
-      <PostDate>{feed.createdAt}</PostDate>
+      <PostDate>{formatFeedDate(feed.createdAt)}</PostDate>
     </InfoContainer>
   );
 };

--- a/src/components/mypage/MyPageContent.tsx
+++ b/src/components/mypage/MyPageContent.tsx
@@ -34,7 +34,20 @@ const MyPageContent = () => {
       )}
 
       {activeTab === 'scrap' && isOwner && (
-        <MyPageSection title="스크랩북" items={profile.bookmarkedFeeds ?? []} type="feed" />
+        <>
+          {profile.bookmarkedFeeds && profile.bookmarkedFeeds.length > 0 && (
+            <MyPageSection title="북마크한 피드" items={profile.bookmarkedFeeds} type="feed" />
+          )}
+          {profile.bookmarkedPacks && profile.bookmarkedPacks.length > 0 && (
+            <MyPageSection title="북마크한 팩" items={profile.bookmarkedPacks} type="pack" />
+          )}
+          {(!profile.bookmarkedFeeds || profile.bookmarkedFeeds.length === 0) &&
+            (!profile.bookmarkedPacks || profile.bookmarkedPacks.length === 0) && (
+              <div style={{ padding: '2rem', textAlign: 'center', color: '#666' }}>
+                북마크한 게시글이 없습니다.
+              </div>
+            )}
+        </>
       )}
     </>
   );

--- a/src/components/mypage/MyPageSection.tsx
+++ b/src/components/mypage/MyPageSection.tsx
@@ -7,17 +7,17 @@ import {
 } from '@/components/mypage/MyPageSection.styles';
 import { useMyPage } from '@/hooks/useMyPageContext';
 import { MY_PAGE_PREVIEW_LIMIT } from '@/constants/myPage';
-import type { FeedItem, PackItem } from '@/types/User';
+import type { FeedItem, PackItem, BookmarkedFeedItem } from '@/types/User';
 
 type Props = {
   title: string;
-  items: FeedItem[] | PackItem[];
+  items: FeedItem[] | PackItem[] | BookmarkedFeedItem[];
   type: 'feed' | 'pack';
 };
 
 const MyPageSection = ({ title, items, type }: Props) => {
   const navigate = useNavigate();
-  const { activeTab, setActiveTab, profile } = useMyPage();
+  const { activeTab, setActiveTab } = useMyPage();
 
   if (!items?.length) return null;
 
@@ -27,33 +27,33 @@ const MyPageSection = ({ title, items, type }: Props) => {
   };
 
   const visibleItems = activeTab === 'all' ? items.slice(0, MY_PAGE_PREVIEW_LIMIT) : items;
-  const totalCount =
-    type === 'feed' ? (profile?.feeds?.length ?? 0) : (profile?.packs?.length ?? 0);
 
   return (
     <SectionWrapper>
       <Header>
-        <h3>
-          {title} {totalCount}
-        </h3>
+        <h3>{title}</h3>
         {activeTab === 'all' && <button onClick={handleViewAll}>전체보기</button>}
       </Header>
 
       <Grid>
-        {visibleItems.map((item, index) => (
-          <PreviewImage
-            key={index}
-            src={type === 'feed' ? (item as FeedItem).imageUrl : (item as PackItem).mainImageUrl}
-            alt={title}
-            onClick={() => {
-              if (type === 'feed' && 'feedId' in item) {
-                navigate(`/feed/${item.feedId}`);
-              } else if (type === 'pack' && 'packId' in item) {
-                navigate(`/starterpack/${item.packId}`);
-              }
-            }}
-          />
-        ))}
+        {visibleItems.map((item, index) => {
+          const imageUrl =
+            type === 'feed'
+              ? 'imageUrl' in item
+                ? item.imageUrl
+                : (item as PackItem).mainImageUrl
+              : (item as PackItem).mainImageUrl;
+
+          const handleClick = () => {
+            if (type === 'feed' && 'feedId' in item) {
+              navigate(`/feed/${item.feedId}`);
+            } else if (type === 'pack' && 'packId' in item) {
+              navigate(`/starterpack/${item.packId}`);
+            }
+          };
+
+          return <PreviewImage key={index} src={imageUrl} alt={title} onClick={handleClick} />;
+        })}
       </Grid>
     </SectionWrapper>
   );

--- a/src/hooks/useStarterPacks.ts
+++ b/src/hooks/useStarterPacks.ts
@@ -425,6 +425,7 @@ export const useStarterPackBookmark = (id: number) => {
           '북마크 처리에 실패했습니다.'
         )
       : null,
+    rawError: toggleBookmarkMutation.error,
   };
 };
 

--- a/src/hooks/useStarterPacks.ts
+++ b/src/hooks/useStarterPacks.ts
@@ -309,6 +309,7 @@ export const useStarterPackLike = (id: number) => {
           '좋아요 처리에 실패했습니다.'
         )
       : null,
+    rawError: toggleLikeMutation.error,
   };
 };
 

--- a/src/pages/StarterPackDetailPage.styles.ts
+++ b/src/pages/StarterPackDetailPage.styles.ts
@@ -198,8 +198,8 @@ export const CategoryTag = styled.div`
   align-items: center;
   gap: 0.25rem;
   padding: 0.25rem 0.75rem;
-  background-color: #f0f8ff;
-  color: #0095f6;
+  background-color: ${tokens.colors.orange.muted};
+  color: ${tokens.colors.orange.primary};
   border-radius: 1rem;
   font-size: 0.75rem;
   font-weight: 500;

--- a/src/pages/StarterPackDetailPage.tsx
+++ b/src/pages/StarterPackDetailPage.tsx
@@ -9,7 +9,7 @@ import {
   usePackCommentActions,
   useStarterPackActions,
 } from '@/hooks/useStarterPacks';
-import { useUser } from '@/hooks/useAuth';
+import { useUser, useAuth } from '@/hooks/useAuth';
 import CommentSection from '@/components/comment/CommentSection';
 import type { Comment, CreateCommentRequest, CreateReplyRequest } from '@/types/Feed';
 import type { StarterPack } from '@/types/StarterPack';
@@ -58,11 +58,12 @@ const StarterPackDetailPage: React.FC = () => {
   const packId = id ? parseInt(id, 10) : 0;
 
   const { starterPack, loading, error } = useStarterPackById(packId);
-  const { toggleLike } = useStarterPackLike(packId);
+  const { toggleLike, error: likeError, rawError } = useStarterPackLike(packId);
   const { comments, refresh: refreshComments } = usePackComments(packId);
   const { addComment: addCommentApi } = usePackCommentActions(packId);
   const { remove: deletePack, loading: isActionLoading } = useStarterPackActions();
   const { data: currentUser } = useUser();
+  const { isLogin } = useAuth();
   const [localComments, setLocalComments] = useState<Comment[]>([]);
 
   // 작성자 확인: 현재 사용자와 스타터팩 작성자 비교
@@ -102,8 +103,28 @@ const StarterPackDetailPage: React.FC = () => {
   };
 
   const handleLike = () => {
+    if (!isLogin) {
+      alert('로그인이 필요한 기능입니다.');
+      navigate('/login');
+      return;
+    }
     toggleLike();
   };
+
+  // 좋아요 에러 처리
+  useEffect(() => {
+    if (rawError) {
+      const axiosError = rawError as { response?: { status?: number } };
+      const status = axiosError?.response?.status;
+      
+      if (status === 403) {
+        alert('로그인이 필요한 기능입니다.');
+        navigate('/login');
+      } else if (likeError) {
+        alert(likeError);
+      }
+    }
+  }, [rawError, likeError, navigate]);
 
   const handleAddComment = async (comment: CreateCommentRequest) => {
     if (!packId) return;

--- a/src/pages/suspense/FeedDetailPageSuspense.tsx
+++ b/src/pages/suspense/FeedDetailPageSuspense.tsx
@@ -105,22 +105,13 @@ const FeedDetailData = () => {
     });
   };
 
-  const handleBookmark = (isBookmarked: boolean, bookmarkCount: number) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const handleBookmark = (_isBookmarked: boolean, _bookmarkCount: number) => {
     if (!isLogin) {
       alert('로그인이 필요한 기능입니다.');
       navigate('/login');
       return;
     }
-
-    // 낙관적 업데이트
-    setLocalFeed((prev) => ({ ...prev, isBookmarked, bookmarkCount }));
-
-    queryClient.setQueryData(QUERY_KEYS.feeds.detail(feedId), (old: FeedDetail | undefined) => {
-      if (!old) return old;
-      return { ...old, isBookmarked, bookmarkCount };
-    });
-
-    // 실제 API 호출
     toggleBookmark();
   };
 

--- a/src/pages/suspense/FeedDetailPageSuspense.tsx
+++ b/src/pages/suspense/FeedDetailPageSuspense.tsx
@@ -7,9 +7,9 @@ import FeedInfoSection from '@/components/feed/FeedInfoSection';
 import CommentSection from '@/components/comment/CommentSection';
 import FeedLikersModal from '@/components/feed/FeedLikersModal';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useCommentActions } from '@/hooks/useFeeds';
+import { useCommentActions, useFeedBookmark } from '@/hooks/useFeeds';
 import { fetchFeedById, deleteFeed } from '@/api/feedApi';
-import { useUser } from '@/hooks/useAuth';
+import { useUser, useAuth } from '@/hooks/useAuth';
 import type { FeedDetail, CreateCommentRequest, CreateReplyRequest } from '@/types/Feed';
 import SuspenseFallback from '@/components/common/SuspenseFallback';
 import ErrorBoundaryWithRecovery from '@/components/common/ErrorBoundaryWithRecovery';
@@ -47,6 +47,8 @@ const FeedDetailData = () => {
   });
 
   const { addComment } = useCommentActions(feedId);
+  const { toggleBookmark } = useFeedBookmark(feedId);
+  const { isLogin } = useAuth();
 
   // 작성자 확인: 현재 사용자와 피드 작성자 비교
   const isAuthor = currentUser?.userId === feed?.author.userId;
@@ -104,12 +106,22 @@ const FeedDetailData = () => {
   };
 
   const handleBookmark = (isBookmarked: boolean, bookmarkCount: number) => {
+    if (!isLogin) {
+      alert('로그인이 필요한 기능입니다.');
+      navigate('/login');
+      return;
+    }
+
+    // 낙관적 업데이트
     setLocalFeed((prev) => ({ ...prev, isBookmarked, bookmarkCount }));
 
     queryClient.setQueryData(QUERY_KEYS.feeds.detail(feedId), (old: FeedDetail | undefined) => {
       if (!old) return old;
       return { ...old, isBookmarked, bookmarkCount };
     });
+
+    // 실제 API 호출
+    toggleBookmark();
   };
 
   const handleAddComment = async (comment: CreateCommentRequest) => {

--- a/src/pages/suspense/StarterPackDetailPageSuspense.tsx
+++ b/src/pages/suspense/StarterPackDetailPageSuspense.tsx
@@ -94,6 +94,21 @@ const StarterPackDetailData = () => {
     }
   }, [comments, currentCommentsKey]);
 
+  // 좋아요 에러 처리
+  useEffect(() => {
+    if (rawError) {
+      const axiosError = rawError as { response?: { status?: number } };
+      const status = axiosError?.response?.status;
+
+      if (status === 403) {
+        alert('로그인이 필요한 기능입니다.');
+        navigate('/login');
+      } else if (likeError) {
+        alert(likeError);
+      }
+    }
+  }, [rawError, likeError, navigate]);
+
   const handleLikeComment = useCallback(
     (commentId: number, isLiked: boolean, likeCount: number) => {
       setLocalComments((prev) =>
@@ -171,21 +186,6 @@ const StarterPackDetailData = () => {
     }
     toggleLike();
   };
-
-  // 좋아요 에러 처리
-  useEffect(() => {
-    if (rawError) {
-      const axiosError = rawError as { response?: { status?: number } };
-      const status = axiosError?.response?.status;
-
-      if (status === 403) {
-        alert('로그인이 필요한 기능입니다.');
-        navigate('/login');
-      } else if (likeError) {
-        alert(likeError);
-      }
-    }
-  }, [rawError, likeError, navigate]);
 
   const handleShare = async () => {
     try {

--- a/src/pages/suspense/StarterPackDetailPageSuspense.tsx
+++ b/src/pages/suspense/StarterPackDetailPageSuspense.tsx
@@ -14,6 +14,7 @@ import {
   useStarterPackBookmark,
 } from '@/hooks/useStarterPacks';
 import { useAuth } from '@/hooks/useAuth';
+import { formatFeedDate } from '@/utils/date';
 import SuspenseFallback from '@/components/common/SuspenseFallback';
 import ErrorBoundaryWithRecovery from '@/components/common/ErrorBoundaryWithRecovery';
 import {
@@ -30,6 +31,9 @@ import {
   MediaImage,
   InfoSection,
   StarterPackHeader,
+  UserInfo,
+  Avatar,
+  Username,
   StarterPackTitle,
   StarterPackDescription,
   CategoryTag,
@@ -43,6 +47,7 @@ import {
   ProductCard,
   ProductImage,
   ProductName,
+  TimeStamp,
   ErrorStateContainer,
 } from '@/pages/StarterPackDetailPage.styles';
 
@@ -252,8 +257,17 @@ const StarterPackDetailData = () => {
           <RightColumn>
             <InfoSection>
               <StarterPackHeader>
-                <StarterPackTitle>{displayPack.name}</StarterPackTitle>
+                <UserInfo>
+                  <Avatar
+                    src={displayPack.authorProfileImageUrl || defaultAvatar}
+                    alt={displayPack.authorNickname || '작성자'}
+                  />
+                  <Username>@{displayPack.authorNickname}</Username>
+                </UserInfo>
               </StarterPackHeader>
+
+              <StarterPackTitle>{displayPack.name}</StarterPackTitle>
+
               <StarterPackDescription>{displayPack.description}</StarterPackDescription>
 
               <CategoryTag>
@@ -269,10 +283,6 @@ const StarterPackDetailData = () => {
                 <StatItem>
                   <MessageSquare size={16} />
                   {displayPack.commentCount || 0}개
-                </StatItem>
-                <StatItem>
-                  <Bookmark size={16} />
-                  {displayPack.bookmarkCount || 0}개
                 </StatItem>
               </StatsSection>
 
@@ -299,6 +309,12 @@ const StarterPackDetailData = () => {
                   북마크
                 </ActionButton>
               </ActionButtons>
+
+              {(displayPack as StarterPack & { createdAt?: string }).createdAt && (
+                <TimeStamp>
+                  {formatFeedDate((displayPack as StarterPack & { createdAt?: string }).createdAt!)}
+                </TimeStamp>
+              )}
             </InfoSection>
           </RightColumn>
         </TopSection>

--- a/src/pages/suspense/StarterPackDetailPageSuspense.tsx
+++ b/src/pages/suspense/StarterPackDetailPageSuspense.tsx
@@ -12,6 +12,7 @@ import {
   usePackCommentActions,
   useStarterPackLike,
 } from '@/hooks/useStarterPacks';
+import { useAuth } from '@/hooks/useAuth';
 import SuspenseFallback from '@/components/common/SuspenseFallback';
 import ErrorBoundaryWithRecovery from '@/components/common/ErrorBoundaryWithRecovery';
 import {
@@ -61,7 +62,8 @@ const StarterPackDetailData = () => {
 
   const { comments, refresh: refreshComments } = usePackComments(packId);
   const { addComment: addCommentApi } = usePackCommentActions(packId);
-  const { toggleLike } = useStarterPackLike(packId);
+  const { toggleLike, error: likeError, rawError } = useStarterPackLike(packId);
+  const { isLogin } = useAuth();
   const [localComments, setLocalComments] = useState<Comment[]>([]);
   const prevCommentsKeyRef = useRef<string>('');
 
@@ -162,8 +164,28 @@ const StarterPackDetailData = () => {
   };
 
   const handleLike = () => {
+    if (!isLogin) {
+      alert('로그인이 필요한 기능입니다.');
+      navigate('/login');
+      return;
+    }
     toggleLike();
   };
+
+  // 좋아요 에러 처리
+  useEffect(() => {
+    if (rawError) {
+      const axiosError = rawError as { response?: { status?: number } };
+      const status = axiosError?.response?.status;
+
+      if (status === 403) {
+        alert('로그인이 필요한 기능입니다.');
+        navigate('/login');
+      } else if (likeError) {
+        alert(likeError);
+      }
+    }
+  }, [rawError, likeError, navigate]);
 
   const handleShare = async () => {
     try {

--- a/src/pages/suspense/StarterPackDetailPageSuspense.tsx
+++ b/src/pages/suspense/StarterPackDetailPageSuspense.tsx
@@ -11,6 +11,7 @@ import {
   usePackComments,
   usePackCommentActions,
   useStarterPackLike,
+  useStarterPackBookmark,
 } from '@/hooks/useStarterPacks';
 import { useAuth } from '@/hooks/useAuth';
 import SuspenseFallback from '@/components/common/SuspenseFallback';
@@ -63,6 +64,11 @@ const StarterPackDetailData = () => {
   const { comments, refresh: refreshComments } = usePackComments(packId);
   const { addComment: addCommentApi } = usePackCommentActions(packId);
   const { toggleLike, error: likeError, rawError } = useStarterPackLike(packId);
+  const {
+    toggleBookmark,
+    error: bookmarkError,
+    rawError: bookmarkRawError,
+  } = useStarterPackBookmark(packId);
   const { isLogin } = useAuth();
   const [localComments, setLocalComments] = useState<Comment[]>([]);
   const prevCommentsKeyRef = useRef<string>('');
@@ -108,6 +114,21 @@ const StarterPackDetailData = () => {
       }
     }
   }, [rawError, likeError, navigate]);
+
+  // 북마크 에러 처리
+  useEffect(() => {
+    if (bookmarkRawError) {
+      const axiosError = bookmarkRawError as { response?: { status?: number } };
+      const status = axiosError?.response?.status;
+
+      if (status === 403) {
+        alert('로그인이 필요한 기능입니다.');
+        navigate('/login');
+      } else if (bookmarkError) {
+        alert(bookmarkError);
+      }
+    }
+  }, [bookmarkRawError, bookmarkError, navigate]);
 
   const handleLikeComment = useCallback(
     (commentId: number, isLiked: boolean, likeCount: number) => {
@@ -199,8 +220,17 @@ const StarterPackDetailData = () => {
   };
 
   const handleBookmark = () => {
-    // 북마크 기능은 이미 구현되어 있음
+    if (!isLogin) {
+      alert('로그인이 필요한 기능입니다.');
+      navigate('/login');
+      return;
+    }
+    toggleBookmark();
   };
+
+  // 북마크 상태 확인
+  const packWithBookmark = displayPack as StarterPack & { isBookmarked?: boolean };
+  const isBookmarked = packWithBookmark?.isBookmarked ?? false;
 
   return (
     <StarterPackDetailPageContainer>
@@ -255,8 +285,17 @@ const StarterPackDetailData = () => {
                   <Share size={20} />
                   공유
                 </ActionButton>
-                <ActionButton onClick={handleBookmark}>
-                  <Bookmark size={20} />
+                <ActionButton
+                  onClick={handleBookmark}
+                  type="button"
+                  aria-label={isBookmarked ? '북마크 취소' : '북마크'}
+                  aria-pressed={isBookmarked}
+                >
+                  <Bookmark
+                    size={20}
+                    fill={isBookmarked ? '#3b82f6' : 'none'}
+                    color={isBookmarked ? '#3b82f6' : '#000'}
+                  />
                   북마크
                 </ActionButton>
               </ActionButtons>

--- a/src/types/StarterPack.ts
+++ b/src/types/StarterPack.ts
@@ -27,6 +27,7 @@ export interface StarterPack {
   authorProfileImageUrl?: string;
   memberId: number;
   isBookmarked?: boolean;
+  createdAt?: string;
 }
 
 export interface StarterPackResponse {

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -10,6 +10,7 @@ export interface UserProfile {
   packs: PackItem[];
   feeds: FeedItem[];
   bookmarkedFeeds?: BookmarkedFeedItem[];
+  bookmarkedPacks?: PackItem[];
   isMe: boolean;
 }
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -81,3 +81,51 @@ export const formatSimpleDate = (dateString: string): string => {
     day: '2-digit',
   });
 };
+
+/**
+ * 피드 게시물 날짜 포맷팅 (오늘: "11시 38분", 어제 이전: "n일 전")
+ * @param dateString - ISO 8601 형식의 날짜 문자열
+ * @returns 포맷팅된 날짜 문자열
+ */
+export const formatFeedDate = (dateString: string): string => {
+  const now = new Date();
+  const postDate = new Date(dateString);
+
+  // 오늘인지 확인 (년, 월, 일 비교)
+  const isToday =
+    now.getFullYear() === postDate.getFullYear() &&
+    now.getMonth() === postDate.getMonth() &&
+    now.getDate() === postDate.getDate();
+
+  if (isToday) {
+    // 오늘 작성된 게시물: "11시 38분" 형식
+    const hours = postDate.getHours();
+    const minutes = postDate.getMinutes();
+    return `${hours}시 ${minutes.toString().padStart(2, '0')}분`;
+  }
+
+  // 어제 이전: "n일 전" 형식
+  const diffInSeconds = Math.floor((now.getTime() - postDate.getTime()) / 1000);
+  const diffInDays = Math.floor(diffInSeconds / 86400);
+
+  if (diffInDays === 1) {
+    return '어제';
+  }
+
+  if (diffInDays < 7) {
+    return `${diffInDays}일 전`;
+  }
+
+  if (diffInDays < 30) {
+    const weeks = Math.floor(diffInDays / 7);
+    return `${weeks}주 전`;
+  }
+
+  if (diffInDays < 365) {
+    const months = Math.floor(diffInDays / 30);
+    return `${months}개월 전`;
+  }
+
+  const years = Math.floor(diffInDays / 365);
+  return `${years}년 전`;
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -91,11 +91,13 @@ export const formatFeedDate = (dateString: string): string => {
   const now = new Date();
   const postDate = new Date(dateString);
 
-  // 오늘인지 확인 (년, 월, 일 비교)
-  const isToday =
-    now.getFullYear() === postDate.getFullYear() &&
-    now.getMonth() === postDate.getMonth() &&
-    now.getDate() === postDate.getDate();
+  // 오늘 날짜 (시간 제외, 00:00:00)
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  // 게시물 날짜 (시간 제외, 00:00:00)
+  const postDay = new Date(postDate.getFullYear(), postDate.getMonth(), postDate.getDate());
+
+  // 오늘인지 확인
+  const isToday = today.getTime() === postDay.getTime();
 
   if (isToday) {
     // 오늘 작성된 게시물: "11시 38분" 형식
@@ -104,9 +106,10 @@ export const formatFeedDate = (dateString: string): string => {
     return `${hours}시 ${minutes.toString().padStart(2, '0')}분`;
   }
 
-  // 어제 이전: "n일 전" 형식
-  const diffInSeconds = Math.floor((now.getTime() - postDate.getTime()) / 1000);
-  const diffInDays = Math.floor(diffInSeconds / 86400);
+  // 날짜 차이 계산 (밀리초 단위)
+  const diffInMs = today.getTime() - postDay.getTime();
+  // 일수 차이
+  const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
 
   if (diffInDays === 1) {
     return '어제';


### PR DESCRIPTION
## ✨ 주요 변경사항

### 1. 스타터팩 디테일 페이지 개선
- **작성자 정보 표시 추가**: 프로필 이미지와 닉네임 표시
- **작성 시각 표시 추가**: 피드와 동일한 형식으로 날짜 표시 (오늘: "11시 38분", 어제 이전: "n일 전")
- **태그 색상 변경**: 파란색 → 오렌지색으로 변경하여 피드와 일관성 유지
- **북마크 개수 제거**: 통계 섹션에서 북마크 개수 표시 제거

### 2. 북마크 기능 구현
- **스타터팩 북마크 토글**: 북마크 버튼 클릭 시 아이콘이 파란색으로 채워지도록 구현
- **마이페이지 스크랩북 연동**: 북마크한 피드와 팩을 마이페이지 스크랩북 탭에서 확인 가능
- **낙관적 업데이트**: 북마크 토글 시 즉시 UI 반영 및 서버 동기화

### 3. 인증 및 보안 개선
- **CSRF 토큰 추가**: 좋아요, 코멘트, 북마크 등 POST/PUT/DELETE 요청에 CSRF 토큰 전달
- **로그인 상태 확인**: 좋아요/북마크 버튼 클릭 전 로그인 상태 확인
- **에러 처리 개선**: 403 에러 발생 시 명확한 메시지 표시 및 로그인 페이지로 리다이렉트

### 4. 피드 UI 개선
- **본문 줄간격 조정**: `line-height: 1.5` → `1.25`로 변경하여 가독성 향상
- **날짜 형식 개선**: ISO 8601 형식 → 사용자 친화적 형식으로 변경
  - 오늘 작성: "11시 38분"
  - 어제: "어제"
  - 7일 이내: "n일 전"
  - 그 외: "n주 전", "n개월 전", "n년 전"

### 5. 버그 수정
- **React Hooks 규칙 준수**: `useEffect`를 early return 이전으로 이동하여 린트 오류 해결
- **북마크 롤백 로직 개선**: FeedPage 북마크 토글 실패 시 원본 상태로 정확히 복구

### 6. 배포 설정
- **Vercel SPA 라우팅**: `vercel.json`에 rewrites 설정 추가하여 새로고침 시 404 오류 해결

## 🔧 기술적 변경사항

### 타입 정의
- `StarterPack` 타입에 `createdAt?: string` 필드 추가
- `UserProfile` 타입에 `bookmarkedPacks?: PackItem[]` 필드 추가

### API 호출
- 모든 POST/PUT/DELETE 요청에 `ensureCsrfToken()` 호출 추가
- 에러 처리 시 원본 에러(`rawError`) 반환하여 상태 코드 확인 가능

### 컴포넌트 구조
- 스타터팩 디테일 페이지에 작성자 정보 섹션 추가
- 마이페이지 스크랩북에서 피드와 팩을 분리하여 표시
- `src/api/starterPackApi.ts`
- `src/utils/date.ts`
- `src/types/StarterPack.ts`
- `src/types/User.ts`
- `vercel.json`

## 🧪 테스트
- [x] 스타터팩 디테일 페이지에서 북마크 토글 동작 확인
- [x] 마이페이지 스크랩북에서 북마크한 항목 표시 확인
- [x] 로그인하지 않은 사용자의 좋아요/북마크 시도 시 로그인 페이지로 리다이렉트 확인
- [x] 피드 날짜 형식이 올바르게 표시되는지 확인
- [x] Vercel 배포 후 새로고침 시 404 오류가 발생하지 않는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security: CSRF protection enforced for all state-changing feed and starter-pack actions.
  * Like/bookmark actions now require login and handle auth errors with prompts.

* **New Features**
  * Feed and starter-pack bookmarking added with visual state.
  * Starter pack pages show author info and formatted creation timestamps.

* **UI**
  * My Page shows bookmarked packs separately and an empty-state message when none exist.

* **Style**
  * Denser post text (reduced line-height) and updated category tag colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->