### PR TITLE
Feed-and-bookmark-jungsanghwa

### DIFF
--- a/src/api/feedApi.ts
+++ b/src/api/feedApi.ts
@@ -31,8 +31,49 @@ export const fetchFeeds = async (
       params.sort = options.sort;
     }
 
-    const response = await axiosInstance.get<FeedResponse>('/api/feeds', { params });
-    return response.data;
+    const response = await axiosInstance.get<
+      FeedResponse & {
+        content: Array<
+          FeedPost & {
+            stats?: { likeCount?: number; bookmarkCount?: number };
+            interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
+          }
+        >;
+      }
+    >('/api/feeds', { params });
+
+    const feedList = response.data.content as Array<
+      FeedPost & {
+        stats?: { likeCount?: number; bookmarkCount?: number };
+        interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
+      }
+    >;
+
+    const normalizedContent = feedList.map(({ stats, interactionStatus, ...feed }) => {
+      const likeCount =
+        typeof feed.likeCount === 'number' ? feed.likeCount : (stats?.likeCount ?? 0);
+      const bookmarkCount =
+        typeof feed.bookmarkCount === 'number' ? feed.bookmarkCount : (stats?.bookmarkCount ?? 0);
+      const isLiked =
+        typeof feed.isLiked === 'boolean' ? feed.isLiked : (interactionStatus?.isLiked ?? false);
+      const isBookmarked =
+        typeof feed.isBookmarked === 'boolean'
+          ? feed.isBookmarked
+          : (interactionStatus?.isBookmarked ?? false);
+
+      return {
+        ...feed,
+        likeCount,
+        bookmarkCount,
+        isLiked,
+        isBookmarked,
+      };
+    });
+
+    return {
+      ...response.data,
+      content: normalizedContent,
+    };
   } catch (error) {
     console.error('Failed to fetch feeds:', error);
     throw error;

--- a/src/api/feedApi.ts
+++ b/src/api/feedApi.ts
@@ -42,8 +42,37 @@ export const fetchFeeds = async (
 // 특정 피드 상세 조회
 export const fetchFeedById = async (id: number): Promise<FeedDetail> => {
   try {
-    const response = await axiosInstance.get<FeedDetail>(`/api/feeds/${id}`);
-    return response.data;
+    const response = await axiosInstance.get<
+      FeedDetail & {
+        stats?: { likeCount?: number; commentCount?: number; bookmarkCount?: number };
+        interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
+      }
+    >(`/api/feeds/${id}`);
+    const data = response.data;
+
+    const likeCount =
+      typeof data.likeCount === 'number' ? data.likeCount : (data.stats?.likeCount ?? 0);
+    const commentCount =
+      typeof data.commentCount === 'number' ? data.commentCount : (data.stats?.commentCount ?? 0);
+    const bookmarkCount =
+      typeof data.bookmarkCount === 'number'
+        ? data.bookmarkCount
+        : (data.stats?.bookmarkCount ?? 0);
+    const isLiked =
+      typeof data.isLiked === 'boolean' ? data.isLiked : (data.interactionStatus?.isLiked ?? false);
+    const isBookmarked =
+      typeof data.isBookmarked === 'boolean'
+        ? data.isBookmarked
+        : (data.interactionStatus?.isBookmarked ?? false);
+
+    return {
+      ...data,
+      likeCount,
+      commentCount,
+      bookmarkCount,
+      isLiked,
+      isBookmarked,
+    };
   } catch (error) {
     console.error(`Failed to fetch feed ${id}:`, error);
     throw error;

--- a/src/components/feed/FeedInfoSection.styles.ts
+++ b/src/components/feed/FeedInfoSection.styles.ts
@@ -61,6 +61,27 @@ export const PostDate = styled.div`
   text-align: left;
 `;
 
+export const StatsSection = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+`;
+
+export const StatItem = styled.div<{ $clickable?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  color: ${tokens.colors.text.mediumGray};
+  cursor: ${(props) => (props.$clickable ? 'pointer' : 'default')};
+  transition: color 0.2s ease;
+
+  &:hover {
+    ${(props) => (props.$clickable ? `color: ${tokens.colors.orange.primary};` : '')}
+  }
+`;
+
 export const ProductSection = styled.div`
   background: ${tokens.colors.orange.muted};
   border-radius: 0.5rem;

--- a/src/components/feed/FeedInfoSection.styles.ts
+++ b/src/components/feed/FeedInfoSection.styles.ts
@@ -117,6 +117,28 @@ export const ActionButton = styled.button`
   }
 `;
 
+export const HashtagSection = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+`;
+
+export const Hashtag = styled.span`
+  background: ${tokens.colors.orange.muted};
+  color: ${tokens.colors.feed.hashtag};
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.2s;
+
+  &:hover {
+    background: ${tokens.colors.orange.light};
+    color: ${tokens.colors.orange.dark};
+  }
+`;
+
 export const ProductSection = styled.div`
   background: ${tokens.colors.orange.muted};
   border-radius: 0.5rem;

--- a/src/components/feed/FeedInfoSection.styles.ts
+++ b/src/components/feed/FeedInfoSection.styles.ts
@@ -4,23 +4,25 @@ import { tokens } from '@/styles/tokens';
 export const InfoContainer = styled.div`
   background: ${tokens.colors.background.card};
   border-radius: 0.5rem;
-  padding: 1.25rem;
+  padding: 1.75rem 1.5rem;
   box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.1);
   text-align: left;
   height: fit-content;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 `;
 
 export const UserProfile = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 1rem;
+  gap: 0.75rem;
 `;
 
 export const ProfileImage = styled.img`
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
-  margin-right: 0.75rem;
   object-fit: cover;
   border: 0.125rem solid ${tokens.colors.orange.light};
 `;
@@ -47,9 +49,9 @@ export const UserBio = styled.p`
 
 export const PostContent = styled.div`
   font-size: 1rem;
-  line-height: 1.25;
+  line-height: 1.6;
   color: ${tokens.colors.text.black};
-  margin-bottom: 0.5rem;
+  margin: 0;
   white-space: pre-line;
   text-align: left;
 `;
@@ -57,22 +59,20 @@ export const PostContent = styled.div`
 export const PostDate = styled.div`
   font-size: 0.875rem;
   color: ${tokens.colors.text.lightGray};
-  margin-bottom: 1rem;
   text-align: left;
 `;
 
 export const StatsSection = styled.div`
   display: flex;
   align-items: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 1.25rem;
 `;
 
 export const StatItem = styled.div<{ $clickable?: boolean }>`
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   color: ${tokens.colors.text.mediumGray};
   cursor: ${(props) => (props.$clickable ? 'pointer' : 'default')};
   transition: color 0.2s ease;
@@ -85,20 +85,19 @@ export const StatItem = styled.div<{ $clickable?: boolean }>`
 export const ActionButtons = styled.div`
   display: flex;
   align-items: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 1.25rem;
 `;
 
 export const ActionButton = styled.button`
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.6rem;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0.5rem;
+  padding: 0.6rem;
   color: ${tokens.colors.text.darkGray};
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   transition: color 0.2s ease;
 
   &:hover:not(:disabled) {
@@ -120,16 +119,15 @@ export const ActionButton = styled.button`
 export const HashtagSection = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  gap: 0.75rem;
 `;
 
 export const Hashtag = styled.span`
   background: ${tokens.colors.orange.muted};
   color: ${tokens.colors.feed.hashtag};
-  padding: 0.25rem 0.5rem;
+  padding: 0.35rem 0.65rem;
   border-radius: 0.75rem;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   font-weight: 500;
   transition: all 0.2s;
 

--- a/src/components/feed/FeedInfoSection.styles.ts
+++ b/src/components/feed/FeedInfoSection.styles.ts
@@ -82,6 +82,41 @@ export const StatItem = styled.div<{ $clickable?: boolean }>`
   }
 `;
 
+export const ActionButtons = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+`;
+
+export const ActionButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
+  color: ${tokens.colors.text.darkGray};
+  font-size: 0.875rem;
+  transition: color 0.2s ease;
+
+  &:hover:not(:disabled) {
+    color: ${tokens.colors.text.mediumGray};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${tokens.colors.orange.primary};
+    outline-offset: 2px;
+    border-radius: 0.25rem;
+  }
+`;
+
 export const ProductSection = styled.div`
   background: ${tokens.colors.orange.muted};
   border-radius: 0.5rem;

--- a/src/components/feed/FeedInfoSection.styles.ts
+++ b/src/components/feed/FeedInfoSection.styles.ts
@@ -137,6 +137,51 @@ export const Hashtag = styled.span`
   }
 `;
 
+export const OwnerActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+  padding-top: 1.25rem;
+  margin-top: 0.5rem;
+  border-top: 1px solid ${tokens.colors.line.lightGray};
+`;
+
+export const OwnerButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: ${tokens.colors.text.mediumGray};
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.4rem;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease;
+
+  &:hover {
+    background: ${tokens.colors.orange.muted};
+    color: ${tokens.colors.orange.dark};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${tokens.colors.orange.primary};
+    outline-offset: 2px;
+  }
+`;
+
+export const OwnerDeleteButton = styled(OwnerButton)`
+  color: #ef4444;
+
+  &:hover {
+    background: rgba(239, 68, 68, 0.1);
+    color: #dc2626;
+  }
+`;
+
 export const ProductSection = styled.div`
   background: ${tokens.colors.orange.muted};
   border-radius: 0.5rem;

--- a/src/components/feed/FeedInfoSection.tsx
+++ b/src/components/feed/FeedInfoSection.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Heart, MessageSquare, Bookmark } from 'lucide-react';
+import { Heart, MessageSquare, Share, Bookmark } from 'lucide-react';
 import type { FeedDetail } from '@/types/Feed';
 import { formatFeedDate } from '@/utils/date';
+import { tokens } from '@/styles/tokens';
 import {
   InfoContainer,
   UserProfile,
@@ -13,14 +14,25 @@ import {
   PostDate,
   StatsSection,
   StatItem,
+  ActionButtons,
+  ActionButton,
 } from '@/components/feed/FeedInfoSection.styles';
 
 interface FeedInfoSectionProps {
   feed: FeedDetail;
+  onLike: () => void;
+  onShare: () => void;
+  onBookmark: () => void;
   onOpenLikers?: () => void;
 }
 
-const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({ feed, onOpenLikers }) => {
+const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({
+  feed,
+  onLike,
+  onShare,
+  onBookmark,
+  onOpenLikers,
+}) => {
   const handleLikeCountClick = () => {
     if (onOpenLikers && feed.likeCount > 0) {
       onOpenLikers();
@@ -56,6 +68,35 @@ const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({ feed, onOpenLikers })
           {feed.bookmarkCount || 0}개
         </StatItem>
       </StatsSection>
+
+      {/* 액션 버튼 */}
+      <ActionButtons>
+        <ActionButton onClick={onLike}>
+          <Heart
+            size={20}
+            fill={feed.isLiked ? tokens.colors.orange.primary : 'none'}
+            color={tokens.colors.orange.primary}
+          />
+          좋아요
+        </ActionButton>
+        <ActionButton onClick={onShare}>
+          <Share size={20} />
+          공유
+        </ActionButton>
+        <ActionButton
+          onClick={onBookmark}
+          type="button"
+          aria-label={feed.isBookmarked ? '북마크 취소' : '북마크'}
+          aria-pressed={feed.isBookmarked}
+        >
+          <Bookmark
+            size={20}
+            fill={feed.isBookmarked ? tokens.colors.orange.primary : 'none'}
+            color={tokens.colors.orange.primary}
+          />
+          북마크
+        </ActionButton>
+      </ActionButtons>
 
       <PostDate>{formatFeedDate(feed.createdAt)}</PostDate>
     </InfoContainer>

--- a/src/components/feed/FeedInfoSection.tsx
+++ b/src/components/feed/FeedInfoSection.tsx
@@ -85,10 +85,6 @@ const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({
           <MessageSquare size={16} />
           {feed.commentCount || 0}개
         </StatItem>
-        <StatItem>
-          <Bookmark size={16} />
-          {feed.bookmarkCount || 0}개
-        </StatItem>
       </StatsSection>
 
       {/* 액션 버튼 */}

--- a/src/components/feed/FeedInfoSection.tsx
+++ b/src/components/feed/FeedInfoSection.tsx
@@ -16,6 +16,8 @@ import {
   StatItem,
   ActionButtons,
   ActionButton,
+  HashtagSection,
+  Hashtag,
 } from '@/components/feed/FeedInfoSection.styles';
 
 interface FeedInfoSectionProps {
@@ -97,6 +99,17 @@ const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({
           북마크
         </ActionButton>
       </ActionButtons>
+
+      {/* 해시태그 */}
+      {feed.hashtags && feed.hashtags.length > 0 && (
+        <HashtagSection>
+          {feed.hashtags.map((tag, index) => {
+            const tagName = typeof tag === 'string' ? tag : tag.hashtagName;
+            const tagKey = typeof tag === 'string' ? tag : tag.id;
+            return <Hashtag key={tagKey || index}>#{tagName}</Hashtag>;
+          })}
+        </HashtagSection>
+      )}
 
       <PostDate>{formatFeedDate(feed.createdAt)}</PostDate>
     </InfoContainer>

--- a/src/components/feed/FeedInfoSection.tsx
+++ b/src/components/feed/FeedInfoSection.tsx
@@ -55,6 +55,17 @@ const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({
       {/* 본문 내용 */}
       <PostContent>{feed.description}</PostContent>
 
+      {/* 해시태그 */}
+      {feed.hashtags && feed.hashtags.length > 0 && (
+        <HashtagSection>
+          {feed.hashtags.map((tag, index) => {
+            const tagName = typeof tag === 'string' ? tag : tag.hashtagName;
+            const tagKey = typeof tag === 'string' ? tag : tag.id;
+            return <Hashtag key={tagKey || index}>#{tagName}</Hashtag>;
+          })}
+        </HashtagSection>
+      )}
+
       {/* 통계 섹션 */}
       <StatsSection>
         <StatItem onClick={handleLikeCountClick} $clickable={feed.likeCount > 0}>
@@ -99,17 +110,6 @@ const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({
           북마크
         </ActionButton>
       </ActionButtons>
-
-      {/* 해시태그 */}
-      {feed.hashtags && feed.hashtags.length > 0 && (
-        <HashtagSection>
-          {feed.hashtags.map((tag, index) => {
-            const tagName = typeof tag === 'string' ? tag : tag.hashtagName;
-            const tagKey = typeof tag === 'string' ? tag : tag.id;
-            return <Hashtag key={tagKey || index}>#{tagName}</Hashtag>;
-          })}
-        </HashtagSection>
-      )}
 
       <PostDate>{formatFeedDate(feed.createdAt)}</PostDate>
     </InfoContainer>

--- a/src/components/feed/FeedInfoSection.tsx
+++ b/src/components/feed/FeedInfoSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Heart, MessageSquare, Share, Bookmark } from 'lucide-react';
+import { Heart, MessageSquare, Share, Bookmark, Edit, Trash2 } from 'lucide-react';
 import type { FeedDetail } from '@/types/Feed';
 import { formatFeedDate } from '@/utils/date';
 import { tokens } from '@/styles/tokens';
@@ -18,6 +18,9 @@ import {
   ActionButton,
   HashtagSection,
   Hashtag,
+  OwnerActions,
+  OwnerButton,
+  OwnerDeleteButton,
 } from '@/components/feed/FeedInfoSection.styles';
 
 interface FeedInfoSectionProps {
@@ -26,6 +29,9 @@ interface FeedInfoSectionProps {
   onShare: () => void;
   onBookmark: () => void;
   onOpenLikers?: () => void;
+  isAuthor?: boolean;
+  onEdit?: () => void;
+  onDelete?: () => void;
 }
 
 const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({
@@ -34,6 +40,9 @@ const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({
   onShare,
   onBookmark,
   onOpenLikers,
+  isAuthor = false,
+  onEdit,
+  onDelete,
 }) => {
   const handleLikeCountClick = () => {
     if (onOpenLikers && feed.likeCount > 0) {
@@ -112,6 +121,19 @@ const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({
       </ActionButtons>
 
       <PostDate>{formatFeedDate(feed.createdAt)}</PostDate>
+
+      {isAuthor && (
+        <OwnerActions>
+          <OwnerButton type="button" onClick={onEdit} aria-label="수정하기">
+            <Edit size={18} />
+            수정
+          </OwnerButton>
+          <OwnerDeleteButton type="button" onClick={onDelete} aria-label="삭제하기">
+            <Trash2 size={18} />
+            삭제
+          </OwnerDeleteButton>
+        </OwnerActions>
+      )}
     </InfoContainer>
   );
 };

--- a/src/components/feed/FeedInfoSection.tsx
+++ b/src/components/feed/FeedInfoSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Heart, MessageSquare, Bookmark } from 'lucide-react';
 import type { FeedDetail } from '@/types/Feed';
 import { formatFeedDate } from '@/utils/date';
 import {
@@ -10,13 +11,22 @@ import {
   UserBio,
   PostContent,
   PostDate,
+  StatsSection,
+  StatItem,
 } from '@/components/feed/FeedInfoSection.styles';
 
 interface FeedInfoSectionProps {
   feed: FeedDetail;
+  onOpenLikers?: () => void;
 }
 
-const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({ feed }) => {
+const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({ feed, onOpenLikers }) => {
+  const handleLikeCountClick = () => {
+    if (onOpenLikers && feed.likeCount > 0) {
+      onOpenLikers();
+    }
+  };
+
   return (
     <InfoContainer>
       {/* 유저 프로필 섹션 */}
@@ -30,6 +40,23 @@ const FeedInfoSection: React.FC<FeedInfoSectionProps> = ({ feed }) => {
 
       {/* 본문 내용 */}
       <PostContent>{feed.description}</PostContent>
+
+      {/* 통계 섹션 */}
+      <StatsSection>
+        <StatItem onClick={handleLikeCountClick} $clickable={feed.likeCount > 0}>
+          <Heart size={16} />
+          {feed.likeCount || 0}개
+        </StatItem>
+        <StatItem>
+          <MessageSquare size={16} />
+          {feed.commentCount || 0}개
+        </StatItem>
+        <StatItem>
+          <Bookmark size={16} />
+          {feed.bookmarkCount || 0}개
+        </StatItem>
+      </StatsSection>
+
       <PostDate>{formatFeedDate(feed.createdAt)}</PostDate>
     </InfoContainer>
   );

--- a/src/components/feed/FeedMediaSection.styles.ts
+++ b/src/components/feed/FeedMediaSection.styles.ts
@@ -4,28 +4,27 @@ import { tokens } from '@/styles/tokens';
 export const MediaContainer = styled.div`
   background: white;
   border-radius: 0.5rem;
-  padding: 1.25rem;
   box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.1);
-  text-align: left;
-  height: fit-content;
+  overflow: hidden;
 `;
 
 export const ImageCarousel = styled.div`
   position: relative;
-  margin-bottom: 1rem;
 `;
 
 export const ImageContainer = styled.div`
   position: relative;
   width: 100%;
-  height: 25rem;
-  border-radius: 0.5rem;
+  height: auto;
+  max-height: 40rem;
   overflow: hidden;
 
   img {
     width: 100%;
-    height: 100%;
+    height: auto;
+    max-height: 40rem;
     object-fit: cover;
+    display: block;
   }
 `;
 

--- a/src/components/feed/FeedMediaSection.tsx
+++ b/src/components/feed/FeedMediaSection.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { Heart, MessageCircle, Bookmark } from 'lucide-react';
 import type { FeedDetail } from '@/types/Feed';
-import { tokens } from '@/styles/tokens';
 import {
   MediaContainer,
   ImageCarousel,
@@ -9,27 +7,13 @@ import {
   ImageNavigation,
   ImageCounter,
   ImageNavButton,
-  EngagementSection,
-  EngagementItem,
-  EngagementIcon,
-  EngagementCount,
-  HashtagSection,
-  Hashtag,
 } from '@/components/feed/FeedMediaSection.styles';
 
 interface FeedMediaSectionProps {
   feed: FeedDetail;
-  onLike: (isLiked: boolean, likeCount: number) => void;
-  onBookmark: (isBookmarked: boolean, bookmarkCount: number) => void;
-  onOpenLikers?: () => void;
 }
 
-const FeedMediaSection: React.FC<FeedMediaSectionProps> = ({
-  feed,
-  onLike,
-  onBookmark,
-  onOpenLikers,
-}) => {
+const FeedMediaSection: React.FC<FeedMediaSectionProps> = ({ feed }) => {
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
   // 이미지가 여러 개인 경우를 위한 배열
@@ -41,25 +25,6 @@ const FeedMediaSection: React.FC<FeedMediaSectionProps> = ({
 
   const handleNextImage = () => {
     setCurrentImageIndex((prev) => (prev === images.length - 1 ? 0 : prev + 1));
-  };
-
-  const handleLike = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onLike(!feed.isLiked, feed.isLiked ? feed.likeCount - 1 : feed.likeCount + 1);
-  };
-
-  const handleLikeCountClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (onOpenLikers && feed.likeCount > 0) {
-      onOpenLikers();
-    }
-  };
-
-  const handleBookmark = () => {
-    onBookmark(
-      !feed.isBookmarked,
-      feed.isBookmarked ? feed.bookmarkCount - 1 : feed.bookmarkCount + 1
-    );
   };
 
   return (
@@ -93,52 +58,6 @@ const FeedMediaSection: React.FC<FeedMediaSectionProps> = ({
             )}
           </ImageContainer>
         </ImageCarousel>
-      )}
-
-      <EngagementSection>
-        <EngagementItem>
-          <EngagementIcon onClick={handleLike}>
-            <Heart
-              size={18}
-              strokeWidth={2}
-              fill={feed.isLiked ? tokens.colors.orange.primary : 'none'}
-              color={tokens.colors.orange.primary}
-            />
-          </EngagementIcon>
-          <EngagementCount onClick={handleLikeCountClick} $clickable={feed.likeCount > 0}>
-            {typeof feed.likeCount === 'number' && !isNaN(feed.likeCount)
-              ? feed.likeCount.toLocaleString()
-              : '0'}
-          </EngagementCount>
-        </EngagementItem>
-        <EngagementItem>
-          <EngagementIcon>
-            <MessageCircle size={18} strokeWidth={2} color={tokens.colors.orange.primary} />
-          </EngagementIcon>
-          <EngagementCount>{feed.commentCount}</EngagementCount>
-        </EngagementItem>
-        <EngagementItem onClick={handleBookmark}>
-          <EngagementIcon>
-            <Bookmark
-              size={18}
-              strokeWidth={2}
-              fill={feed.isBookmarked ? tokens.colors.orange.primary : 'none'}
-              color={tokens.colors.orange.primary}
-            />
-          </EngagementIcon>
-          <EngagementCount>{feed.bookmarkCount}</EngagementCount>
-        </EngagementItem>
-      </EngagementSection>
-
-      {/* 해시태그 */}
-      {feed.hashtags && feed.hashtags.length > 0 && (
-        <HashtagSection>
-          {feed.hashtags.map((tag, index) => {
-            const tagName = typeof tag === 'string' ? tag : tag.hashtagName;
-            const tagKey = typeof tag === 'string' ? tag : tag.id;
-            return <Hashtag key={tagKey || index}>#{tagName}</Hashtag>;
-          })}
-        </HashtagSection>
       )}
     </MediaContainer>
   );

--- a/src/components/feed/FeedPost.styles.ts
+++ b/src/components/feed/FeedPost.styles.ts
@@ -61,9 +61,10 @@ export const PostImage = styled.img`
 export const PostActions = styled.div`
   display: flex;
   align-items: center;
-  padding: 0.375rem 1rem 0.5rem;
+  padding: 0.75rem 1rem;
   gap: 1.25rem;
   border-bottom: 1px solid ${tokens.colors.line.lightGray};
+  margin-bottom: 0.75rem;
 `;
 
 export const EngagementItem = styled.div`
@@ -137,15 +138,17 @@ export const LikesCount = styled.div`
   font-weight: 600;
   font-size: 0.875rem;
   color: ${tokens.colors.text.darkGray};
-  padding: 0 1rem 0.5rem;
+  padding: 0 1rem;
   text-align: left;
+  margin-bottom: 0.75rem;
 `;
 
 export const Caption = styled.div`
-  padding: 0 1rem 0.5rem;
+  padding: 0 1rem;
   font-size: 0.875rem;
-  line-height: 1.4;
+  line-height: 1.5;
   color: ${tokens.colors.text.darkGray};
+  margin-bottom: 0.75rem;
 
   ${Username} {
     font-weight: 600;
@@ -180,7 +183,7 @@ export const CommentsCount = styled.div`
 `;
 
 export const TimeStamp = styled.div`
-  padding: 0 1rem 0.75rem;
+  padding: 0 1rem 1rem;
   font-size: 0.625rem;
   color: ${tokens.colors.text.mediumGray};
   text-transform: uppercase;
@@ -191,49 +194,26 @@ export const CategoryTag = styled.div`
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0 1rem 0.5rem;
+  padding: 0 1rem;
   font-size: 0.75rem;
   color: ${tokens.colors.orange.primary};
   font-weight: 500;
+  margin-bottom: 0.5rem;
 `;
 
-export const FeedTypeTag = styled.div<{ $feedType: string }>`
-  display: inline-block;
-  padding: 0.25rem 0.5rem;
-  margin: 0 1rem 0.5rem;
-  font-size: 0.625rem;
-  font-weight: 600;
-  border-radius: 0.25rem;
+export const FeedTypeTag = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.75rem;
+  margin: 0 1rem 0.75rem;
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: ${tokens.colors.text.mediumGray};
+  background: #f3f4f6;
+  border: 1px solid ${tokens.colors.line.lightGray};
   text-transform: uppercase;
-  letter-spacing: 0.03125rem;
-  background-color: ${(props) => {
-    switch (props.$feedType) {
-      case 'INFO':
-        return '#e3f2fd';
-      case 'REVIEW':
-        return '#f3e5f5';
-      case 'QUESTION':
-        return '#fff3e0';
-      case 'TIP':
-        return '#e8f5e8';
-      default:
-        return '#f5f5f5';
-    }
-  }};
-  color: ${(props) => {
-    switch (props.$feedType) {
-      case 'INFO':
-        return '#1976d2';
-      case 'REVIEW':
-        return '#7b1fa2';
-      case 'QUESTION':
-        return '#f57c00';
-      case 'TIP':
-        return '#388e3c';
-      default:
-        return '#666';
-    }
-  }};
 `;
 
 export const ProductsSection = styled.div`

--- a/src/components/feed/FeedPost.tsx
+++ b/src/components/feed/FeedPost.tsx
@@ -128,7 +128,7 @@ const FeedPost = ({ post, onLike, onBookmark }: FeedPostProps) => {
             src={post.author.profileImageUrl}
             alt={post.author.name}
             onClick={handleProfileClick}
-            style={{ cursor: 'pointer' }} 
+            style={{ cursor: 'pointer' }}
           />
           <Username onClick={handleProfileClick} style={{ cursor: 'pointer' }}>
             @{post.author.name}
@@ -197,7 +197,21 @@ const FeedPost = ({ post, onLike, onBookmark }: FeedPostProps) => {
         {post.category.categoryName}
       </CategoryTag>
 
-      <FeedTypeTag $feedType={post.feedType}>{post.feedType}</FeedTypeTag>
+      {Array.isArray(post.hashtags) && post.hashtags.length > 0 && (
+        <Caption as="div" style={{ color: tokens.colors.orange.primary, marginBottom: '0.75rem' }}>
+          {post.hashtags.map((hashtag) => {
+            const tagName = typeof hashtag === 'string' ? hashtag : hashtag.hashtagName;
+            const tagKey = typeof hashtag === 'string' ? hashtag : hashtag.id;
+            return (
+              <span key={tagKey} style={{ marginRight: '0.5rem', fontWeight: 500 }}>
+                #{tagName}
+              </span>
+            );
+          })}
+        </Caption>
+      )}
+
+      {post.feedType && <FeedTypeTag>{post.feedType}</FeedTypeTag>}
 
       <TimeStamp>{formatTimeAgo(post.createdAt)}</TimeStamp>
     </PostContainer>

--- a/src/components/home/feedpreview/StyleFeedPreview.tsx
+++ b/src/components/home/feedpreview/StyleFeedPreview.tsx
@@ -120,7 +120,6 @@ const StyleFeedPreview = () => {
         likeCount: feed.likeCount ?? 0,
       };
 
-      // 낙관적 업데이트 (isPending 플래그 설정)
       const newIsLiked = !currentLike.isLiked;
       const newLikeCount = newIsLiked
         ? currentLike.likeCount + 1

--- a/src/pages/FeedDetailPage.tsx
+++ b/src/pages/FeedDetailPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Edit, Trash2 } from 'lucide-react';
 import FeedMediaSection from '@/components/feed/FeedMediaSection';
@@ -6,8 +6,8 @@ import FeedInfoSection from '@/components/feed/FeedInfoSection';
 import CommentSection from '@/components/comment/CommentSection';
 import type { CreateCommentRequest, CreateReplyRequest } from '@/types/Feed';
 import { useFeedDetail } from '@/hooks/useFeedDetail';
-import { useCommentActions } from '@/hooks/useFeeds';
-import { useUser } from '@/hooks/useAuth';
+import { useCommentActions, useFeedBookmark, useFeedLike } from '@/hooks/useFeeds';
+import { useUser, useAuth } from '@/hooks/useAuth';
 import { deleteFeed } from '@/api/feedApi';
 import {
   FeedDetailPageContainer,
@@ -33,21 +33,76 @@ const FeedDetailPage: React.FC = () => {
   const navigate = useNavigate();
   const { feed, loading, error, updateFeed, refetch } = useFeedDetail(id);
   const { data: currentUser } = useUser();
+  const { isLogin } = useAuth();
 
   // feedId가 있을 때만 댓글 액션 훅 사용
   const feedId = feed?.feedId;
   const { addComment: addCommentApi } = useCommentActions(feedId || 0);
+  const { toggleLike } = useFeedLike(feedId || 0);
+  const { toggleBookmark } = useFeedBookmark(feedId || 0);
 
   // 작성자 확인: 현재 사용자와 피드 작성자 비교
   const isAuthor = currentUser?.userId === feed?.author.userId;
 
-  const handleLike = (isLiked: boolean, likeCount: number) => {
-    updateFeed({ isLiked, likeCount });
-  };
+  const handleLike = useCallback(() => {
+    if (!feed || !feedId) return;
+    if (!isLogin) {
+      alert('로그인이 필요한 기능입니다.');
+      navigate('/login');
+      return;
+    }
 
-  const handleBookmark = (isBookmarked: boolean, bookmarkCount: number) => {
-    updateFeed({ isBookmarked, bookmarkCount });
-  };
+    const newIsLiked = !feed.isLiked;
+    const newLikeCount = newIsLiked
+      ? (feed.likeCount ?? 0) + 1
+      : Math.max(0, (feed.likeCount ?? 0) - 1);
+
+    updateFeed({ isLiked: newIsLiked, likeCount: newLikeCount });
+    toggleLike();
+  }, [feed, feedId, isLogin, navigate, toggleLike, updateFeed]);
+
+  const handleShare = useCallback(() => {
+    if (!feed) return;
+
+    if (navigator.share) {
+      navigator
+        .share({
+          title: '피드 공유',
+          text: feed.description || '',
+          url: window.location.href,
+        })
+        .catch((shareError) => {
+          console.error('공유 실패:', shareError);
+        });
+    } else {
+      navigator.clipboard
+        .writeText(window.location.href)
+        .then(() => {
+          alert('링크가 클립보드에 복사되었습니다.');
+        })
+        .catch((clipboardError) => {
+          console.error('클립보드 복사 실패:', clipboardError);
+          alert('공유 기능을 사용할 수 없습니다.');
+        });
+    }
+  }, [feed]);
+
+  const handleBookmark = useCallback(() => {
+    if (!feed || !feedId) return;
+    if (!isLogin) {
+      alert('로그인이 필요한 기능입니다.');
+      navigate('/login');
+      return;
+    }
+
+    const newIsBookmarked = !feed.isBookmarked;
+    const newBookmarkCount = newIsBookmarked
+      ? (feed.bookmarkCount ?? 0) + 1
+      : Math.max(0, (feed.bookmarkCount ?? 0) - 1);
+
+    updateFeed({ isBookmarked: newIsBookmarked, bookmarkCount: newBookmarkCount });
+    toggleBookmark();
+  }, [feed, feedId, isLogin, navigate, toggleBookmark, updateFeed]);
 
   const handleAddComment = async (comment: CreateCommentRequest) => {
     if (feedId === undefined) return;
@@ -186,11 +241,16 @@ const FeedDetailPage: React.FC = () => {
       <ContentContainer>
         <TopSection>
           <LeftColumn>
-            <FeedMediaSection feed={feed} onLike={handleLike} onBookmark={handleBookmark} />
+            <FeedMediaSection feed={feed} />
           </LeftColumn>
 
           <RightColumn>
-            <FeedInfoSection feed={feed} />
+            <FeedInfoSection
+              feed={feed}
+              onLike={handleLike}
+              onShare={handleShare}
+              onBookmark={handleBookmark}
+            />
             {isAuthor && (
               <ActionButtons>
                 <ActionButton onClick={handleEdit} type="button" aria-label="수정하기">

--- a/src/pages/StarterPackDetailPage.styles.ts
+++ b/src/pages/StarterPackDetailPage.styles.ts
@@ -206,6 +206,28 @@ export const CategoryTag = styled.div`
   margin-bottom: 1rem;
 `;
 
+export const HashtagSection = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+`;
+
+export const Hashtag = styled.span`
+  background: ${tokens.colors.orange.muted};
+  color: ${tokens.colors.feed.hashtag};
+  padding: 0.35rem 0.65rem;
+  border-radius: 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.2s;
+
+  &:hover {
+    background: ${tokens.colors.orange.light};
+    color: ${tokens.colors.orange.dark};
+  }
+`;
+
 export const StatsSection = styled.div`
   display: flex;
   align-items: center;

--- a/src/pages/StarterPackDetailPage.styles.ts
+++ b/src/pages/StarterPackDetailPage.styles.ts
@@ -268,6 +268,51 @@ export const DeleteButton = styled(ActionButton)`
   }
 `;
 
+export const OwnerActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid ${tokens.colors.line.lightGray};
+`;
+
+export const OwnerButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: ${tokens.colors.text.mediumGray};
+  padding: 0.45rem 0.65rem;
+  border-radius: 0.4rem;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease;
+
+  &:hover {
+    background: ${tokens.colors.orange.muted};
+    color: ${tokens.colors.orange.dark};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${tokens.colors.orange.primary};
+    outline-offset: 2px;
+  }
+`;
+
+export const OwnerDeleteButton = styled(OwnerButton)`
+  color: #ef4444;
+
+  &:hover {
+    background: rgba(239, 68, 68, 0.1);
+    color: #dc2626;
+  }
+`;
+
 export const ProductsSection = styled.div`
   margin-top: 1rem;
   padding-top: 1rem;

--- a/src/pages/suspense/FeedDetailPageSuspense.tsx
+++ b/src/pages/suspense/FeedDetailPageSuspense.tsx
@@ -199,7 +199,7 @@ const FeedDetailData = () => {
           </LeftColumn>
 
           <RightColumn>
-            <FeedInfoSection feed={localFeed} />
+            <FeedInfoSection feed={localFeed} onOpenLikers={() => setIsLikersModalOpen(true)} />
             {isAuthor && (
               <ActionButtons>
                 <ActionButton onClick={handleEdit} type="button" aria-label="수정하기">

--- a/src/pages/suspense/FeedDetailPageSuspense.tsx
+++ b/src/pages/suspense/FeedDetailPageSuspense.tsx
@@ -7,12 +7,9 @@ import FeedInfoSection from '@/components/feed/FeedInfoSection';
 import CommentSection from '@/components/comment/CommentSection';
 import FeedLikersModal from '@/components/feed/FeedLikersModal';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useCommentActions } from '@/hooks/useFeeds';
+import { useCommentActions, useFeedLike, useFeedBookmark } from '@/hooks/useFeeds';
 import { fetchFeedById, deleteFeed } from '@/api/feedApi';
-import { useUser } from '@/hooks/useAuth';
-// TODO: 2단계에서 FeedInfoSection으로 이동할 예정
-// import { useFeedBookmark } from '@/hooks/useFeeds';
-// import { useAuth } from '@/hooks/useAuth';
+import { useUser, useAuth } from '@/hooks/useAuth';
 import type { FeedDetail, CreateCommentRequest, CreateReplyRequest } from '@/types/Feed';
 import SuspenseFallback from '@/components/common/SuspenseFallback';
 import ErrorBoundaryWithRecovery from '@/components/common/ErrorBoundaryWithRecovery';
@@ -50,9 +47,9 @@ const FeedDetailData = () => {
   });
 
   const { addComment } = useCommentActions(feedId);
-  // TODO: 2단계에서 FeedInfoSection으로 이동할 예정
-  // const { toggleBookmark } = useFeedBookmark(feedId);
-  // const { isLogin } = useAuth();
+  const { toggleLike } = useFeedLike(feedId);
+  const { toggleBookmark } = useFeedBookmark(feedId);
+  const { isLogin } = useAuth();
 
   // 작성자 확인: 현재 사용자와 피드 작성자 비교
   const isAuthor = currentUser?.userId === feed?.author.userId;
@@ -100,24 +97,48 @@ const FeedDetailData = () => {
     }
   };
 
-  // TODO: 2단계에서 FeedInfoSection으로 이동할 예정
-  // const handleLike = (isLiked: boolean, likeCount: number) => {
-  //   setLocalFeed((prev) => ({ ...prev, isLiked, likeCount }));
-  //   queryClient.setQueryData(QUERY_KEYS.feeds.detail(feedId), (old: FeedDetail | undefined) => {
-  //     if (!old) return old;
-  //     return { ...old, isLiked, likeCount };
-  //   });
-  // };
+  const handleLike = () => {
+    if (!isLogin) {
+      alert('로그인이 필요한 기능입니다.');
+      navigate('/login');
+      return;
+    }
+    toggleLike();
+  };
 
-  // TODO: 2단계에서 FeedInfoSection으로 이동할 예정
-  // const handleBookmark = (_isBookmarked: boolean, _bookmarkCount: number) => {
-  //   if (!isLogin) {
-  //     alert('로그인이 필요한 기능입니다.');
-  //     navigate('/login');
-  //     return;
-  //   }
-  //   toggleBookmark();
-  // };
+  const handleShare = () => {
+    if (navigator.share) {
+      navigator
+        .share({
+          title: '피드 공유',
+          text: feed?.description || '',
+          url: window.location.href,
+        })
+        .catch((error) => {
+          console.error('공유 실패:', error);
+        });
+    } else {
+      // 공유 API를 지원하지 않는 경우 클립보드에 복사
+      navigator.clipboard
+        .writeText(window.location.href)
+        .then(() => {
+          alert('링크가 클립보드에 복사되었습니다.');
+        })
+        .catch((error) => {
+          console.error('클립보드 복사 실패:', error);
+          alert('공유 기능을 사용할 수 없습니다.');
+        });
+    }
+  };
+
+  const handleBookmark = () => {
+    if (!isLogin) {
+      alert('로그인이 필요한 기능입니다.');
+      navigate('/login');
+      return;
+    }
+    toggleBookmark();
+  };
 
   const handleAddComment = async (comment: CreateCommentRequest) => {
     try {
@@ -199,7 +220,13 @@ const FeedDetailData = () => {
           </LeftColumn>
 
           <RightColumn>
-            <FeedInfoSection feed={localFeed} onOpenLikers={() => setIsLikersModalOpen(true)} />
+            <FeedInfoSection
+              feed={localFeed}
+              onLike={handleLike}
+              onShare={handleShare}
+              onBookmark={handleBookmark}
+              onOpenLikers={() => setIsLikersModalOpen(true)}
+            />
             {isAuthor && (
               <ActionButtons>
                 <ActionButton onClick={handleEdit} type="button" aria-label="수정하기">

--- a/src/pages/suspense/FeedDetailPageSuspense.tsx
+++ b/src/pages/suspense/FeedDetailPageSuspense.tsx
@@ -1,7 +1,6 @@
 import { Suspense, useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
-import { Edit, Trash2 } from 'lucide-react';
 import FeedMediaSection from '@/components/feed/FeedMediaSection';
 import FeedInfoSection from '@/components/feed/FeedInfoSection';
 import CommentSection from '@/components/comment/CommentSection';
@@ -24,9 +23,6 @@ import {
   LeftColumn,
   RightColumn,
   BottomSection,
-  ActionButtons,
-  ActionButton,
-  DeleteButton,
 } from '@/pages/FeedDetailPage.styles';
 
 const FeedDetailData = () => {
@@ -226,19 +222,10 @@ const FeedDetailData = () => {
               onShare={handleShare}
               onBookmark={handleBookmark}
               onOpenLikers={() => setIsLikersModalOpen(true)}
+              isAuthor={isAuthor}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
             />
-            {isAuthor && (
-              <ActionButtons>
-                <ActionButton onClick={handleEdit} type="button" aria-label="수정하기">
-                  <Edit size={20} />
-                  수정하기
-                </ActionButton>
-                <DeleteButton onClick={handleDelete} type="button" aria-label="삭제하기">
-                  <Trash2 size={20} />
-                  삭제하기
-                </DeleteButton>
-              </ActionButtons>
-            )}
           </RightColumn>
         </TopSection>
 

--- a/src/pages/suspense/FeedDetailPageSuspense.tsx
+++ b/src/pages/suspense/FeedDetailPageSuspense.tsx
@@ -7,9 +7,12 @@ import FeedInfoSection from '@/components/feed/FeedInfoSection';
 import CommentSection from '@/components/comment/CommentSection';
 import FeedLikersModal from '@/components/feed/FeedLikersModal';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useCommentActions, useFeedBookmark } from '@/hooks/useFeeds';
+import { useCommentActions } from '@/hooks/useFeeds';
 import { fetchFeedById, deleteFeed } from '@/api/feedApi';
-import { useUser, useAuth } from '@/hooks/useAuth';
+import { useUser } from '@/hooks/useAuth';
+// TODO: 2단계에서 FeedInfoSection으로 이동할 예정
+// import { useFeedBookmark } from '@/hooks/useFeeds';
+// import { useAuth } from '@/hooks/useAuth';
 import type { FeedDetail, CreateCommentRequest, CreateReplyRequest } from '@/types/Feed';
 import SuspenseFallback from '@/components/common/SuspenseFallback';
 import ErrorBoundaryWithRecovery from '@/components/common/ErrorBoundaryWithRecovery';
@@ -47,8 +50,9 @@ const FeedDetailData = () => {
   });
 
   const { addComment } = useCommentActions(feedId);
-  const { toggleBookmark } = useFeedBookmark(feedId);
-  const { isLogin } = useAuth();
+  // TODO: 2단계에서 FeedInfoSection으로 이동할 예정
+  // const { toggleBookmark } = useFeedBookmark(feedId);
+  // const { isLogin } = useAuth();
 
   // 작성자 확인: 현재 사용자와 피드 작성자 비교
   const isAuthor = currentUser?.userId === feed?.author.userId;
@@ -96,24 +100,24 @@ const FeedDetailData = () => {
     }
   };
 
-  const handleLike = (isLiked: boolean, likeCount: number) => {
-    setLocalFeed((prev) => ({ ...prev, isLiked, likeCount }));
+  // TODO: 2단계에서 FeedInfoSection으로 이동할 예정
+  // const handleLike = (isLiked: boolean, likeCount: number) => {
+  //   setLocalFeed((prev) => ({ ...prev, isLiked, likeCount }));
+  //   queryClient.setQueryData(QUERY_KEYS.feeds.detail(feedId), (old: FeedDetail | undefined) => {
+  //     if (!old) return old;
+  //     return { ...old, isLiked, likeCount };
+  //   });
+  // };
 
-    queryClient.setQueryData(QUERY_KEYS.feeds.detail(feedId), (old: FeedDetail | undefined) => {
-      if (!old) return old;
-      return { ...old, isLiked, likeCount };
-    });
-  };
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handleBookmark = (_isBookmarked: boolean, _bookmarkCount: number) => {
-    if (!isLogin) {
-      alert('로그인이 필요한 기능입니다.');
-      navigate('/login');
-      return;
-    }
-    toggleBookmark();
-  };
+  // TODO: 2단계에서 FeedInfoSection으로 이동할 예정
+  // const handleBookmark = (_isBookmarked: boolean, _bookmarkCount: number) => {
+  //   if (!isLogin) {
+  //     alert('로그인이 필요한 기능입니다.');
+  //     navigate('/login');
+  //     return;
+  //   }
+  //   toggleBookmark();
+  // };
 
   const handleAddComment = async (comment: CreateCommentRequest) => {
     try {
@@ -191,12 +195,7 @@ const FeedDetailData = () => {
       <ContentContainer>
         <TopSection>
           <LeftColumn>
-            <FeedMediaSection
-              feed={localFeed}
-              onLike={handleLike}
-              onBookmark={handleBookmark}
-              onOpenLikers={() => setIsLikersModalOpen(true)}
-            />
+            <FeedMediaSection feed={localFeed} />
           </LeftColumn>
 
           <RightColumn>

--- a/src/pages/suspense/FeedDetailPageSuspense.tsx
+++ b/src/pages/suspense/FeedDetailPageSuspense.tsx
@@ -103,18 +103,19 @@ const FeedDetailData = () => {
   };
 
   const handleShare = () => {
+    if (!feed) return;
+
     if (navigator.share) {
       navigator
         .share({
           title: '피드 공유',
-          text: feed?.description || '',
+          text: feed.description || '',
           url: window.location.href,
         })
         .catch((error) => {
           console.error('공유 실패:', error);
         });
-    } else {
-      // 공유 API를 지원하지 않는 경우 클립보드에 복사
+    } else if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
       navigator.clipboard
         .writeText(window.location.href)
         .then(() => {
@@ -122,8 +123,18 @@ const FeedDetailData = () => {
         })
         .catch((error) => {
           console.error('클립보드 복사 실패:', error);
-          alert('공유 기능을 사용할 수 없습니다.');
+          alert('링크 복사에 실패했습니다. 다시 시도해주세요.');
         });
+    } else {
+      try {
+        window.prompt(
+          '공유 기능을 지원하지 않는 환경입니다. URL을 직접 복사해주세요.',
+          window.location.href
+        );
+      } catch (error) {
+        console.error('URL 안내 중 오류가 발생했습니다:', error);
+        alert(`아래 URL을 직접 복사해주세요:\n${window.location.href}`);
+      }
     }
   };
 

--- a/src/pages/suspense/StarterPackDetailPageSuspense.tsx
+++ b/src/pages/suspense/StarterPackDetailPageSuspense.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Heart, MessageSquare, Share, Bookmark, Tag } from 'lucide-react';
+import { Heart, MessageSquare, Share, Bookmark, Tag, Edit, Trash2 } from 'lucide-react';
 import defaultAvatar from '@/assets/icon-smile.svg';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { fetchStarterPackById } from '@/api/starterPackApi';
@@ -13,12 +13,14 @@ import {
   useStarterPackLike,
   usePackCommentLike,
   useStarterPackBookmark,
+  useStarterPackActions,
 } from '@/hooks/useStarterPacks';
-import { useAuth } from '@/hooks/useAuth';
+import { useAuth, useUser } from '@/hooks/useAuth';
 import { QUERY_KEYS } from '@/utils/queryKeys';
 import { formatFeedDate } from '@/utils/date';
 import SuspenseFallback from '@/components/common/SuspenseFallback';
 import ErrorBoundaryWithRecovery from '@/components/common/ErrorBoundaryWithRecovery';
+import { tokens } from '@/styles/tokens';
 import {
   StarterPackDetailPageContainer,
   PageHeader,
@@ -51,6 +53,9 @@ import {
   ProductName,
   TimeStamp,
   ErrorStateContainer,
+  OwnerActions,
+  OwnerButton,
+  OwnerDeleteButton,
 } from '@/pages/StarterPackDetailPage.styles';
 
 const StarterPackDetailData = () => {
@@ -78,7 +83,9 @@ const StarterPackDetailData = () => {
     rawError: commentLikeRawError,
   } = usePackCommentLike(packId);
   const { toggleBookmark } = useStarterPackBookmark(packId);
+  const { remove: deletePack, loading: isActionLoading } = useStarterPackActions();
   const { isLogin } = useAuth();
+  const { data: currentUser } = useUser();
   const [localComments, setLocalComments] = useState<Comment[]>([]);
   const prevCommentsKeyRef = useRef<string>('');
 
@@ -232,9 +239,36 @@ const StarterPackDetailData = () => {
     toggleBookmark();
   };
 
+  const handleEdit = () => {
+    navigate(`/pack-writing?edit=${packId}`);
+  };
+
+  const handleDelete = async () => {
+    if (!packId) return;
+
+    const confirmed = window.confirm(
+      '정말로 이 스타터팩을 삭제하시겠습니까?\n삭제된 스타터팩은 복구할 수 없습니다.'
+    );
+    if (!confirmed) return;
+
+    try {
+      await deletePack(packId);
+      alert('스타터팩이 삭제되었습니다.');
+      navigate('/starterpack');
+    } catch (error) {
+      console.error('Failed to delete starter pack:', error);
+      alert('스타터팩 삭제에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
+
   // 북마크 상태 확인
-  const packWithBookmark = displayPack as StarterPack & { isBookmarked?: boolean };
+  const packWithBookmark = displayPack as StarterPack & {
+    isBookmarked?: boolean;
+    isLiked?: boolean;
+  };
   const isBookmarked = packWithBookmark?.isBookmarked ?? false;
+  const isLiked = packWithBookmark?.isLiked ?? false;
+  const isAuthor = currentUser?.userId === displayPack.memberId;
 
   return (
     <StarterPackDetailPageContainer>
@@ -286,11 +320,15 @@ const StarterPackDetailData = () => {
               </StatsSection>
 
               <ActionButtons>
-                <ActionButton onClick={handleLike}>
-                  <Heart size={20} />
+                <ActionButton onClick={handleLike} type="button" aria-pressed={isLiked}>
+                  <Heart
+                    size={20}
+                    fill={isLiked ? tokens.colors.orange.primary : 'none'}
+                    color={tokens.colors.orange.primary}
+                  />
                   좋아요
                 </ActionButton>
-                <ActionButton onClick={handleShare}>
+                <ActionButton onClick={handleShare} type="button">
                   <Share size={20} />
                   공유
                 </ActionButton>
@@ -302,8 +340,8 @@ const StarterPackDetailData = () => {
                 >
                   <Bookmark
                     size={20}
-                    fill={isBookmarked ? '#3b82f6' : 'none'}
-                    color={isBookmarked ? '#3b82f6' : '#000'}
+                    fill={isBookmarked ? tokens.colors.orange.primary : 'none'}
+                    color={tokens.colors.orange.primary}
                   />
                   북마크
                 </ActionButton>
@@ -313,6 +351,24 @@ const StarterPackDetailData = () => {
                 <TimeStamp>
                   {formatFeedDate((displayPack as StarterPack & { createdAt?: string }).createdAt!)}
                 </TimeStamp>
+              )}
+
+              {isAuthor && (
+                <OwnerActions>
+                  <OwnerButton type="button" onClick={handleEdit} aria-label="수정하기">
+                    <Edit size={18} />
+                    수정
+                  </OwnerButton>
+                  <OwnerDeleteButton
+                    type="button"
+                    onClick={handleDelete}
+                    aria-label="삭제하기"
+                    disabled={isActionLoading}
+                  >
+                    <Trash2 size={18} />
+                    삭제
+                  </OwnerDeleteButton>
+                </OwnerActions>
               )}
             </InfoSection>
           </RightColumn>

--- a/src/pages/suspense/StarterPackDetailPageSuspense.tsx
+++ b/src/pages/suspense/StarterPackDetailPageSuspense.tsx
@@ -41,6 +41,8 @@ import {
   StarterPackTitle,
   StarterPackDescription,
   CategoryTag,
+  HashtagSection,
+  Hashtag,
   StatsSection,
   StatItem,
   ActionButtons,
@@ -369,6 +371,14 @@ const StarterPackDetailData = () => {
                 <Tag size={16} />
                 {displayPack.categoryName}
               </CategoryTag>
+
+              {displayPack.hashtags && displayPack.hashtags.length > 0 && (
+                <HashtagSection>
+                  {displayPack.hashtags.map((tag) => (
+                    <Hashtag key={tag.id}>#{tag.hashtagName}</Hashtag>
+                  ))}
+                </HashtagSection>
+              )}
 
               <StatsSection>
                 <StatItem>

--- a/src/pages/suspense/StarterPackDetailPageSuspense.tsx
+++ b/src/pages/suspense/StarterPackDetailPageSuspense.tsx
@@ -4,7 +4,7 @@ import { Heart, MessageSquare, Share, Bookmark, Tag, Edit, Trash2 } from 'lucide
 import defaultAvatar from '@/assets/icon-smile.svg';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { fetchStarterPackById } from '@/api/starterPackApi';
-import type { StarterPack } from '@/types/StarterPack';
+import type { StarterPack, PackCommentResponse } from '@/types/StarterPack';
 import type { Comment, CreateCommentRequest, CreateReplyRequest } from '@/types/Feed';
 import CommentSection from '@/components/comment/CommentSection';
 import {
@@ -57,6 +57,25 @@ import {
   OwnerButton,
   OwnerDeleteButton,
 } from '@/pages/StarterPackDetailPage.styles';
+
+const convertPackCommentToComment = (packComment: PackCommentResponse): Comment => {
+  return {
+    commentId: packComment.id,
+    author: {
+      userId: packComment.author.id,
+      name: packComment.author.name,
+      profileImageUrl: packComment.author.profileImageUrl,
+    },
+    content: packComment.content,
+    createdAt: packComment.createdAt,
+    likeCount: packComment.likeCount ?? 0,
+    isLiked: packComment.isLiked ?? false,
+    parentId: packComment.parentId ?? null,
+    isMine: packComment.isMine ?? false,
+    isDeleted: packComment.isDeleted ?? false,
+    replies: [],
+  };
+};
 
 const StarterPackDetailData = () => {
   const { id } = useParams<{ id: string }>();
@@ -168,27 +187,64 @@ const StarterPackDetailData = () => {
   }, []);
 
   const handleAddComment = async (comment: CreateCommentRequest) => {
-    if (!packId) return;
+    if (!isLogin) {
+      alert('로그인이 필요한 기능입니다.');
+      navigate('/login');
+      return;
+    }
 
     try {
-      await addCommentApi(comment.content, comment.parentId);
+      const created = await addCommentApi(comment.content, comment.parentId ?? null);
+      const newComment = convertPackCommentToComment(created);
+
+      if (created.parentId) {
+        setLocalComments((prev) =>
+          prev.map((item) =>
+            item.commentId === created.parentId
+              ? {
+                  ...item,
+                  replies: [...(item.replies ?? []), newComment],
+                }
+              : item
+          )
+        );
+      } else {
+        setLocalComments((prev) => [...prev, newComment]);
+      }
+
       await refreshComments();
     } catch (error) {
-      console.error('Failed to add comment:', error);
-      alert('댓글 작성에 실패했습니다.');
+      console.error('댓글 작성 실패:', error);
+      alert('댓글 작성에 실패했습니다. 다시 시도해주세요.');
     }
   };
 
   const handleAddReply = async (reply: CreateReplyRequest) => {
-    if (!packId) return;
+    if (!isLogin) {
+      alert('로그인이 필요한 기능입니다.');
+      navigate('/login');
+      return;
+    }
 
     try {
-      // 답글은 parentId를 포함하여 댓글 작성
-      await addCommentApi(reply.content, reply.commentId);
+      const created = await addCommentApi(reply.content, reply.commentId);
+      const replyComment = convertPackCommentToComment(created);
+
+      setLocalComments((prev) =>
+        prev.map((comment) =>
+          comment.commentId === reply.commentId
+            ? {
+                ...comment,
+                replies: [...(comment.replies ?? []), replyComment],
+              }
+            : comment
+        )
+      );
+
       await refreshComments();
     } catch (error) {
-      console.error('Failed to add reply:', error);
-      alert('답글 작성에 실패했습니다.');
+      console.error('답글 작성 실패:', error);
+      alert('답글 작성에 실패했습니다. 다시 시도해주세요.');
     }
   };
 

--- a/src/pages/suspense/StarterPackDetailPageSuspense.tsx
+++ b/src/pages/suspense/StarterPackDetailPageSuspense.tsx
@@ -59,7 +59,7 @@ import {
 } from '@/pages/StarterPackDetailPage.styles';
 
 const convertPackCommentToComment = (packComment: PackCommentResponse): Comment => {
-  return {
+  const baseComment: Comment = {
     commentId: packComment.id,
     author: {
       userId: packComment.author.id,
@@ -75,6 +75,12 @@ const convertPackCommentToComment = (packComment: PackCommentResponse): Comment 
     isDeleted: packComment.isDeleted ?? false,
     replies: [],
   };
+
+  if (packComment.parentId !== null && packComment.parentId !== undefined) {
+    (baseComment as Comment & { replyId: number }).replyId = packComment.id;
+  }
+
+  return baseComment;
 };
 
 const StarterPackDetailData = () => {

--- a/src/types/Feed.ts
+++ b/src/types/Feed.ts
@@ -12,6 +12,7 @@ export interface FeedPost {
     categoryId: number;
     categoryName: string;
   };
+  hashtags?: FeedHashtag[] | string[];
   likeCount: number;
   isLiked: boolean;
   isBookmarked?: boolean;


### PR DESCRIPTION
## 요약
- 피드 상세·목록 API 응답을 정규화해 최초 로딩 시 좋아요/북마크 수가 정확히 표시되도록 개선했습니다.
- 피드 UI를 스타터팩과 유사한 간격·배지 스타일로 정리하고, 상세/프리뷰 카드에 해시태그를 공통적으로 노출하도록 수정했습니다.
- 스타터팩 상세 UX를 다듬어 해시태그 배지를 추가하고, 댓글·답글 작성 시 UI가 즉시 반영되도록 했습니다.

## 상세 변경 사항
- `src/api/feedApi.ts`: 백엔드의 `stats` / `interactionStatus` 정보를 like/bookmark/댓글 수 및 상호작용 플래그에 반영하도록 `fetchFeedById`, `fetchFeeds` 응답을 정규화.
- `src/types/Feed.ts`: 목록 카드에서도 해시태그를 사용할 수 있도록 `FeedPost` 타입에 `hashtags` 옵션 필드를 추가.
- `src/components/feed/FeedPost.tsx`, `FeedPost.styles.ts`:  
  - 액션 바 아래 여백을 늘려 스타터팩 카드와 동일한 레이아웃 제공.  
  - 카테고리 아래에 해시태그 배지 렌더링 추가.  
  - 피드 타입 배지를 은은한 회색으로 변경하고 값이 없으면 숨김 처리.
- `src/components/feed/FeedInfoSection.tsx`: 북마크 카운터 행 제거.
- `src/pages/StarterPackDetailPage.styles.ts`, `StarterPackDetailPageSuspense.tsx`: 카테고리 아래 해시태그 배지 섹션을 추가해 피드 상세와 스타일을 통일.
- `src/pages/suspense/StarterPackDetailPageSuspense.tsx`: 댓글·답글 작성 직후 응답을 `Comment` 형태로 변환해 `localComments`에 즉시 반영.

## 테스트
- [ ] 피드 목록·프리뷰·상세 화면에서 좋아요/북마크 수가 첫 렌더링부터 정확히 표시되는지 확인.
- [ ] 피드 카드에 해시태그·중립 색상의 피드 타입·여유 있는 여백이 적용됐는지 확인.
- [ ] 스타터팩 상세에서 해시태그가 노출되고 댓글/답글 등록이 즉시 UI에 반영되는지 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hashtag display on feed posts
  * Owner controls: edit and delete actions for content owners
  * Share button with native share + clipboard fallback

* **Improvements**
  * Interactive stats: clickable like/comment counts and likers view
  * Action buttons (like, bookmark, share) with updated visuals and accessibility
  * Image carousel: improved scaling, max-height and overflow handling
  * Simplified media view and clearer feed detail composition
* **Behavior**
  * Actions gated by login where applicable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->