### PR TITLE
테스트하며 알려진 오류 해결하기

### DIFF
--- a/src/api/starterPackApi.ts
+++ b/src/api/starterPackApi.ts
@@ -11,6 +11,37 @@ import type {
   PackCommentResponse,
 } from '@/types/StarterPack';
 
+type RawStarterPack = StarterPack & {
+  stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
+  interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
+};
+
+const normalizePack = ({ stats, interactionStatus, ...rest }: RawStarterPack): StarterPack => {
+  const likeCount =
+    typeof rest.likeCount === 'number' ? rest.likeCount : stats?.likeCount ?? 0;
+  const bookmarkCount =
+    typeof rest.bookmarkCount === 'number' ? rest.bookmarkCount : stats?.bookmarkCount ?? 0;
+  const commentCount =
+    typeof rest.commentCount === 'number' ? rest.commentCount : stats?.commentCount ?? 0;
+  const isLiked =
+    typeof rest.isLiked === 'boolean' ? rest.isLiked : interactionStatus?.isLiked ?? false;
+  const isBookmarked =
+    typeof rest.isBookmarked === 'boolean'
+      ? rest.isBookmarked
+      : interactionStatus?.isBookmarked ?? false;
+
+  return {
+    ...rest,
+    likeCount,
+    bookmarkCount,
+    commentCount,
+    isLiked,
+    isBookmarked,
+  };
+};
+
+const normalizePackCollection = (packs: RawStarterPack[] = []) => packs.map(normalizePack);
+
 export const fetchStarterPack = async (
   page: number = 0,
   size: number = 12,
@@ -30,52 +61,17 @@ export const fetchStarterPack = async (
       params.category = options.category;
     }
 
-    const response = await axiosInstance.get<
-      StarterPackResponse & {
-        [key: string]: Array<
-          StarterPack & {
-            stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
-            interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
-          }
-        >;
+    const response = await axiosInstance.get<Record<string, RawStarterPack[]>>(
+      '/api/starterPack/packs',
+      {
+        params,
       }
-    >('/api/starterPack/packs', {
-      params,
-    });
+    );
 
     const normalized: StarterPackResponse = {};
 
     Object.keys(response.data).forEach((key) => {
-      const packs = response.data[key] as Array<
-        StarterPack & {
-          stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
-          interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
-        }
-      >;
-
-      normalized[key] = packs.map(({ stats, interactionStatus, ...rest }) => {
-        const likeCount =
-          typeof rest.likeCount === 'number' ? rest.likeCount : (stats?.likeCount ?? 0);
-        const bookmarkCount =
-          typeof rest.bookmarkCount === 'number' ? rest.bookmarkCount : (stats?.bookmarkCount ?? 0);
-        const commentCount =
-          typeof rest.commentCount === 'number' ? rest.commentCount : (stats?.commentCount ?? 0);
-        const isLiked =
-          typeof rest.isLiked === 'boolean' ? rest.isLiked : (interactionStatus?.isLiked ?? false);
-        const isBookmarked =
-          typeof rest.isBookmarked === 'boolean'
-            ? rest.isBookmarked
-            : (interactionStatus?.isBookmarked ?? false);
-
-        return {
-          ...rest,
-          likeCount,
-          bookmarkCount,
-          commentCount,
-          isLiked,
-          isBookmarked,
-        };
-      });
+      normalized[key] = normalizePackCollection(response.data[key]);
     });
 
     return normalized;
@@ -88,40 +84,9 @@ export const fetchStarterPack = async (
 // 특정 스타터팩 조회
 export const fetchStarterPackById = async (id: number): Promise<StarterPack> => {
   try {
-    const response = await axiosInstance.get<
-      StarterPack & {
-        stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
-        interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
-      }
-    >(`/api/starterPack/packs/${id}`);
+    const response = await axiosInstance.get<RawStarterPack>(`/api/starterPack/packs/${id}`);
 
-    const data = response.data as StarterPack & {
-      stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
-      interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
-    };
-
-    const { stats, interactionStatus, ...rest } = data;
-
-    const likeCount = typeof rest.likeCount === 'number' ? rest.likeCount : (stats?.likeCount ?? 0);
-    const bookmarkCount =
-      typeof rest.bookmarkCount === 'number' ? rest.bookmarkCount : (stats?.bookmarkCount ?? 0);
-    const commentCount =
-      typeof rest.commentCount === 'number' ? rest.commentCount : (stats?.commentCount ?? 0);
-    const isLiked =
-      typeof rest.isLiked === 'boolean' ? rest.isLiked : (interactionStatus?.isLiked ?? false);
-    const isBookmarked =
-      typeof rest.isBookmarked === 'boolean'
-        ? rest.isBookmarked
-        : (interactionStatus?.isBookmarked ?? false);
-
-    return {
-      ...rest,
-      likeCount,
-      bookmarkCount,
-      commentCount,
-      isLiked,
-      isBookmarked,
-    };
+    return normalizePack(response.data);
   } catch (error) {
     console.error(`Failed to fetch starter pack ${id}:`, error);
     throw error;
@@ -219,50 +184,14 @@ export const fetchStarterPackByCategory = async (
   categoryId: number
 ): Promise<StarterPackResponse> => {
   try {
-    const response = await axiosInstance.get<
-      StarterPackResponse & {
-        [key: string]: Array<
-          StarterPack & {
-            stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
-            interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
-          }
-        >;
-      }
-    >(`/api/starterPack/categories/${categoryId}/packs`);
+    const response = await axiosInstance.get<Record<string, RawStarterPack[]>>(
+      `/api/starterPack/categories/${categoryId}/packs`
+    );
 
     const normalized: StarterPackResponse = {};
 
     Object.keys(response.data).forEach((key) => {
-      const packs = response.data[key] as Array<
-        StarterPack & {
-          stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
-          interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
-        }
-      >;
-
-      normalized[key] = packs.map(({ stats, interactionStatus, ...rest }) => {
-        const likeCount =
-          typeof rest.likeCount === 'number' ? rest.likeCount : (stats?.likeCount ?? 0);
-        const bookmarkCount =
-          typeof rest.bookmarkCount === 'number' ? rest.bookmarkCount : (stats?.bookmarkCount ?? 0);
-        const commentCount =
-          typeof rest.commentCount === 'number' ? rest.commentCount : (stats?.commentCount ?? 0);
-        const isLiked =
-          typeof rest.isLiked === 'boolean' ? rest.isLiked : (interactionStatus?.isLiked ?? false);
-        const isBookmarked =
-          typeof rest.isBookmarked === 'boolean'
-            ? rest.isBookmarked
-            : (interactionStatus?.isBookmarked ?? false);
-
-        return {
-          ...rest,
-          likeCount,
-          bookmarkCount,
-          commentCount,
-          isLiked,
-          isBookmarked,
-        };
-      });
+      normalized[key] = normalizePackCollection(response.data[key]);
     });
 
     return normalized;

--- a/src/api/starterPackApi.ts
+++ b/src/api/starterPackApi.ts
@@ -30,10 +30,55 @@ export const fetchStarterPack = async (
       params.category = options.category;
     }
 
-    const response = await axiosInstance.get<StarterPackResponse>('/api/starterPack/packs', {
+    const response = await axiosInstance.get<
+      StarterPackResponse & {
+        [key: string]: Array<
+          StarterPack & {
+            stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
+            interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
+          }
+        >;
+      }
+    >('/api/starterPack/packs', {
       params,
     });
-    return response.data;
+
+    const normalized: StarterPackResponse = {};
+
+    Object.keys(response.data).forEach((key) => {
+      const packs = response.data[key] as Array<
+        StarterPack & {
+          stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
+          interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
+        }
+      >;
+
+      normalized[key] = packs.map(({ stats, interactionStatus, ...rest }) => {
+        const likeCount =
+          typeof rest.likeCount === 'number' ? rest.likeCount : (stats?.likeCount ?? 0);
+        const bookmarkCount =
+          typeof rest.bookmarkCount === 'number' ? rest.bookmarkCount : (stats?.bookmarkCount ?? 0);
+        const commentCount =
+          typeof rest.commentCount === 'number' ? rest.commentCount : (stats?.commentCount ?? 0);
+        const isLiked =
+          typeof rest.isLiked === 'boolean' ? rest.isLiked : (interactionStatus?.isLiked ?? false);
+        const isBookmarked =
+          typeof rest.isBookmarked === 'boolean'
+            ? rest.isBookmarked
+            : (interactionStatus?.isBookmarked ?? false);
+
+        return {
+          ...rest,
+          likeCount,
+          bookmarkCount,
+          commentCount,
+          isLiked,
+          isBookmarked,
+        };
+      });
+    });
+
+    return normalized;
   } catch (error) {
     console.error('Failed to fetch starter packs:', error);
     throw error;
@@ -43,8 +88,40 @@ export const fetchStarterPack = async (
 // 특정 스타터팩 조회
 export const fetchStarterPackById = async (id: number): Promise<StarterPack> => {
   try {
-    const response = await axiosInstance.get<StarterPack>(`/api/starterPack/packs/${id}`);
-    return response.data;
+    const response = await axiosInstance.get<
+      StarterPack & {
+        stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
+        interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
+      }
+    >(`/api/starterPack/packs/${id}`);
+
+    const data = response.data as StarterPack & {
+      stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
+      interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
+    };
+
+    const { stats, interactionStatus, ...rest } = data;
+
+    const likeCount = typeof rest.likeCount === 'number' ? rest.likeCount : (stats?.likeCount ?? 0);
+    const bookmarkCount =
+      typeof rest.bookmarkCount === 'number' ? rest.bookmarkCount : (stats?.bookmarkCount ?? 0);
+    const commentCount =
+      typeof rest.commentCount === 'number' ? rest.commentCount : (stats?.commentCount ?? 0);
+    const isLiked =
+      typeof rest.isLiked === 'boolean' ? rest.isLiked : (interactionStatus?.isLiked ?? false);
+    const isBookmarked =
+      typeof rest.isBookmarked === 'boolean'
+        ? rest.isBookmarked
+        : (interactionStatus?.isBookmarked ?? false);
+
+    return {
+      ...rest,
+      likeCount,
+      bookmarkCount,
+      commentCount,
+      isLiked,
+      isBookmarked,
+    };
   } catch (error) {
     console.error(`Failed to fetch starter pack ${id}:`, error);
     throw error;
@@ -142,10 +219,53 @@ export const fetchStarterPackByCategory = async (
   categoryId: number
 ): Promise<StarterPackResponse> => {
   try {
-    const response = await axiosInstance.get<StarterPackResponse>(
-      `/api/starterPack/categories/${categoryId}/packs`
-    );
-    return response.data;
+    const response = await axiosInstance.get<
+      StarterPackResponse & {
+        [key: string]: Array<
+          StarterPack & {
+            stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
+            interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
+          }
+        >;
+      }
+    >(`/api/starterPack/categories/${categoryId}/packs`);
+
+    const normalized: StarterPackResponse = {};
+
+    Object.keys(response.data).forEach((key) => {
+      const packs = response.data[key] as Array<
+        StarterPack & {
+          stats?: { likeCount?: number; bookmarkCount?: number; commentCount?: number };
+          interactionStatus?: { isLiked?: boolean; isBookmarked?: boolean };
+        }
+      >;
+
+      normalized[key] = packs.map(({ stats, interactionStatus, ...rest }) => {
+        const likeCount =
+          typeof rest.likeCount === 'number' ? rest.likeCount : (stats?.likeCount ?? 0);
+        const bookmarkCount =
+          typeof rest.bookmarkCount === 'number' ? rest.bookmarkCount : (stats?.bookmarkCount ?? 0);
+        const commentCount =
+          typeof rest.commentCount === 'number' ? rest.commentCount : (stats?.commentCount ?? 0);
+        const isLiked =
+          typeof rest.isLiked === 'boolean' ? rest.isLiked : (interactionStatus?.isLiked ?? false);
+        const isBookmarked =
+          typeof rest.isBookmarked === 'boolean'
+            ? rest.isBookmarked
+            : (interactionStatus?.isBookmarked ?? false);
+
+        return {
+          ...rest,
+          likeCount,
+          bookmarkCount,
+          commentCount,
+          isLiked,
+          isBookmarked,
+        };
+      });
+    });
+
+    return normalized;
   } catch (error) {
     console.error(`Failed to fetch starter packs by category ${categoryId}:`, error);
     throw error;

--- a/src/components/common/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute.tsx
@@ -7,8 +7,12 @@ type ProtectedRouteProps = {
 };
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { isLogin } = useAuth();
+  const { isLogin, loading } = useAuth();
   const location = useLocation();
+
+  if (loading) {
+    return null;
+  }
 
   if (!isLogin) {
     return <Navigate to="/login" replace state={{ from: location }} />;

--- a/src/pages/suspense/FeedDetailPageSuspense.tsx
+++ b/src/pages/suspense/FeedDetailPageSuspense.tsx
@@ -7,7 +7,7 @@ import FeedInfoSection from '@/components/feed/FeedInfoSection';
 import CommentSection from '@/components/comment/CommentSection';
 import FeedLikersModal from '@/components/feed/FeedLikersModal';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useCommentActions, useFeedBookmark } from '@/hooks/useFeeds';
+import { useCommentActions, useFeedBookmark, useFeedLike } from '@/hooks/useFeeds';
 import { fetchFeedById, deleteFeed, fetchComments } from '@/api/feedApi';
 import { useUser, useAuth } from '@/hooks/useAuth';
 import type {
@@ -61,6 +61,7 @@ const FeedDetailData = () => {
 
   const { addComment } = useCommentActions(feedId);
   const { toggleBookmark } = useFeedBookmark(feedId);
+  const { toggleLike } = useFeedLike(feedId);
   const { isLogin } = useAuth();
 
   // 작성자 확인: 현재 사용자와 피드 작성자 비교
@@ -109,22 +110,85 @@ const FeedDetailData = () => {
     }
   };
 
-  const handleLike = (isLiked: boolean, likeCount: number) => {
-    setLocalFeed((prev) => ({ ...prev, isLiked, likeCount }));
-
-    queryClient.setQueryData(QUERY_KEYS.feeds.detail(feedId), (old: FeedDetail | undefined) => {
-      if (!old) return old;
-      return { ...old, isLiked, likeCount };
-    });
-  };
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handleBookmark = (_isBookmarked: boolean, _bookmarkCount: number) => {
+  const handleLike = () => {
+    if (!localFeed) return;
     if (!isLogin) {
       alert('로그인이 필요한 기능입니다.');
       navigate('/login');
       return;
     }
+
+    const newIsLiked = !localFeed.isLiked;
+    const newLikeCount = newIsLiked
+      ? (localFeed.likeCount ?? 0) + 1
+      : Math.max(0, (localFeed.likeCount ?? 0) - 1);
+
+    setLocalFeed((prev) =>
+      prev ? { ...prev, isLiked: newIsLiked, likeCount: newLikeCount } : prev
+    );
+
+    queryClient.setQueryData(QUERY_KEYS.feeds.detail(feedId), (old: FeedDetail | undefined) => {
+      if (!old) return old;
+      return { ...old, isLiked: newIsLiked, likeCount: newLikeCount };
+    });
+
+    toggleLike();
+  };
+
+  const handleShare = () => {
+    if (!localFeed) return;
+
+    const shareData = {
+      title: '피드 공유',
+      text: localFeed.description || '',
+      url: window.location.href,
+    };
+
+    if (navigator.share) {
+      navigator.share(shareData).catch((shareError) => {
+        console.error('공유 실패:', shareError);
+      });
+      return;
+    }
+
+    if (navigator.clipboard) {
+      navigator.clipboard
+        .writeText(window.location.href)
+        .then(() => {
+          alert('링크가 클립보드에 복사되었습니다.');
+        })
+        .catch((clipboardError) => {
+          console.error('클립보드 복사 실패:', clipboardError);
+          alert('공유 기능을 사용할 수 없습니다.');
+        });
+      return;
+    }
+
+    alert('이 브라우저에서는 공유 기능을 지원하지 않습니다.');
+  };
+
+  const handleBookmark = () => {
+    if (!localFeed) return;
+    if (!isLogin) {
+      alert('로그인이 필요한 기능입니다.');
+      navigate('/login');
+      return;
+    }
+
+    const newIsBookmarked = !localFeed.isBookmarked;
+    const newBookmarkCount = newIsBookmarked
+      ? (localFeed.bookmarkCount ?? 0) + 1
+      : Math.max(0, (localFeed.bookmarkCount ?? 0) - 1);
+
+    setLocalFeed((prev) =>
+      prev ? { ...prev, isBookmarked: newIsBookmarked, bookmarkCount: newBookmarkCount } : prev
+    );
+
+    queryClient.setQueryData(QUERY_KEYS.feeds.detail(feedId), (old: FeedDetail | undefined) => {
+      if (!old) return old;
+      return { ...old, isBookmarked: newIsBookmarked, bookmarkCount: newBookmarkCount };
+    });
+
     toggleBookmark();
   };
 
@@ -203,16 +267,17 @@ const FeedDetailData = () => {
       <ContentContainer>
         <TopSection>
           <LeftColumn>
-            <FeedMediaSection
-              feed={localFeed}
-              onLike={handleLike}
-              onBookmark={handleBookmark}
-              onOpenLikers={() => setIsLikersModalOpen(true)}
-            />
+            <FeedMediaSection feed={localFeed} />
           </LeftColumn>
 
           <RightColumn>
-            <FeedInfoSection feed={localFeed} />
+            <FeedInfoSection
+              feed={localFeed}
+              onLike={handleLike}
+              onShare={handleShare}
+              onBookmark={handleBookmark}
+              onOpenLikers={() => setIsLikersModalOpen(true)}
+            />
             {isAuthor && (
               <ActionButtons>
                 <ActionButton onClick={handleEdit} type="button" aria-label="수정하기">

--- a/src/pages/suspense/FeedDetailPageSuspense.tsx
+++ b/src/pages/suspense/FeedDetailPageSuspense.tsx
@@ -8,9 +8,14 @@ import CommentSection from '@/components/comment/CommentSection';
 import FeedLikersModal from '@/components/feed/FeedLikersModal';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useCommentActions, useFeedBookmark } from '@/hooks/useFeeds';
-import { fetchFeedById, deleteFeed } from '@/api/feedApi';
+import { fetchFeedById, deleteFeed, fetchComments } from '@/api/feedApi';
 import { useUser, useAuth } from '@/hooks/useAuth';
-import type { FeedDetail, CreateCommentRequest, CreateReplyRequest } from '@/types/Feed';
+import type {
+  FeedDetail,
+  CreateCommentRequest,
+  CreateReplyRequest,
+  CommentResponse,
+} from '@/types/Feed';
 import SuspenseFallback from '@/components/common/SuspenseFallback';
 import ErrorBoundaryWithRecovery from '@/components/common/ErrorBoundaryWithRecovery';
 import { QUERY_KEYS } from '@/utils/queryKeys';
@@ -46,6 +51,14 @@ const FeedDetailData = () => {
     staleTime: 5 * 60 * 1000,
   });
 
+  const { data: commentsResponse } = useSuspenseQuery<CommentResponse>({
+    queryKey: QUERY_KEYS.feeds.comments(feedId),
+    queryFn: () => fetchComments(feedId),
+    staleTime: 60 * 1000,
+  });
+
+  const initialComments = commentsResponse?.content ?? [];
+
   const { addComment } = useCommentActions(feedId);
   const { toggleBookmark } = useFeedBookmark(feedId);
   const { isLogin } = useAuth();
@@ -55,7 +68,7 @@ const FeedDetailData = () => {
 
   const [localFeed, setLocalFeed] = useState<FeedDetail>({
     ...feed,
-    comments: feed?.comments || [],
+    comments: initialComments,
   });
   const [isLikersModalOpen, setIsLikersModalOpen] = useState(false);
 
@@ -63,10 +76,10 @@ const FeedDetailData = () => {
     if (feed) {
       setLocalFeed({
         ...feed,
-        comments: feed.comments || [],
+        comments: commentsResponse?.content ?? [],
       });
     }
-  }, [feed]);
+  }, [feed, commentsResponse]);
 
   const handleBack = () => {
     navigate(-1);
@@ -118,6 +131,7 @@ const FeedDetailData = () => {
   const handleAddComment = async (comment: CreateCommentRequest) => {
     try {
       await addComment(comment);
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.feeds.comments(feedId) });
       alert('댓글이 추가되었습니다!');
     } catch (error) {
       console.error('댓글 작성 실패:', error);
@@ -127,14 +141,12 @@ const FeedDetailData = () => {
 
   const handleAddReply = async (reply: CreateReplyRequest) => {
     try {
-      // 답글은 댓글 작성 API에 parentId를 포함하여 호출
       await addComment({
         feedId: reply.feedId,
         content: reply.content,
         parentId: reply.commentId,
       });
-      // 답글 작성 성공 후 피드 상세 정보 새로고침
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.feeds.detail(feedId) });
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.feeds.comments(feedId) });
       alert('답글이 추가되었습니다!');
     } catch (error) {
       console.error('답글 작성 실패:', error);

--- a/src/pages/suspense/StarterPackDetailPageSuspense.tsx
+++ b/src/pages/suspense/StarterPackDetailPageSuspense.tsx
@@ -19,6 +19,7 @@ import { QUERY_KEYS } from '@/utils/queryKeys';
 import { formatFeedDate } from '@/utils/date';
 import SuspenseFallback from '@/components/common/SuspenseFallback';
 import ErrorBoundaryWithRecovery from '@/components/common/ErrorBoundaryWithRecovery';
+import { tokens } from '@/styles/tokens';
 import {
   StarterPackDetailPageContainer,
   PageHeader,
@@ -232,9 +233,12 @@ const StarterPackDetailData = () => {
     toggleBookmark();
   };
 
-  // 북마크 상태 확인
-  const packWithBookmark = displayPack as StarterPack & { isBookmarked?: boolean };
-  const isBookmarked = packWithBookmark?.isBookmarked ?? false;
+  const packInteraction = displayPack as StarterPack & {
+    isBookmarked?: boolean;
+    isLiked?: boolean;
+  };
+  const isBookmarked = packInteraction?.isBookmarked ?? false;
+  const isLiked = packInteraction?.isLiked ?? false;
 
   return (
     <StarterPackDetailPageContainer>
@@ -286,8 +290,12 @@ const StarterPackDetailData = () => {
               </StatsSection>
 
               <ActionButtons>
-                <ActionButton onClick={handleLike}>
-                  <Heart size={20} />
+                <ActionButton onClick={handleLike} type="button" aria-pressed={isLiked}>
+                  <Heart
+                    size={20}
+                    fill={isLiked ? tokens.colors.orange.primary : 'none'}
+                    color={tokens.colors.orange.primary}
+                  />
                   좋아요
                 </ActionButton>
                 <ActionButton onClick={handleShare}>
@@ -302,8 +310,8 @@ const StarterPackDetailData = () => {
                 >
                   <Bookmark
                     size={20}
-                    fill={isBookmarked ? '#3b82f6' : 'none'}
-                    color={isBookmarked ? '#3b82f6' : '#000'}
+                    fill={isBookmarked ? tokens.colors.orange.primary : 'none'}
+                    color={isBookmarked ? tokens.colors.orange.primary : tokens.colors.text.black}
                   />
                   북마크
                 </ActionButton>

--- a/src/pages/suspense/StarterPackDetailPageSuspense.tsx
+++ b/src/pages/suspense/StarterPackDetailPageSuspense.tsx
@@ -298,7 +298,7 @@ const StarterPackDetailData = () => {
                   />
                   좋아요
                 </ActionButton>
-                <ActionButton onClick={handleShare}>
+                <ActionButton onClick={handleShare} type="button">
                   <Share size={20} />
                   공유
                 </ActionButton>

--- a/src/types/StarterPack.ts
+++ b/src/types/StarterPack.ts
@@ -27,6 +27,7 @@ export interface StarterPack {
   authorProfileImageUrl?: string;
   memberId: number;
   isBookmarked?: boolean;
+  isLiked?: boolean;
   createdAt?: string;
 }
 


### PR DESCRIPTION
1.
스타터팩 상세 좋아요 수가 첫 클릭 때 잘못 줄어드는 원인은, 최초 로딩 시 서버가 내려준 isLiked 상태를 프론트에서 반영하지 않았기 때문이었습니다. 사용자가 이미 좋아요를 누른 상태라도 클라이언트는 isLiked를 기본값(false)으로 간주해 낙관 업데이트가 증가 방향으로 시작했고, 이후 서버 응답(좋아요 취소 결과)로 2개로 내려앉는 문제가 발생했습니다.
이번에 다음과 같이 수정했습니다.
StarterPack 타입에 isLiked 옵션을 추가했습니다.
fetchStarterPackById, fetchStarterPack, fetchStarterPackByCategory 응답을 정규화해 stats, interactionStatus 필드가 내려오는 경우에도 likeCount, bookmarkCount, commentCount, isLiked, isBookmarked 값이 항상 설정되도록 처리했습니다.
스타터팩 상세 화면(StarterPackDetailPageSuspense)에서 isLiked/isBookmarked 값을 읽어 하트 아이콘과 북마크 버튼 상태를 정확히 표시하도록 변경했습니다.
이제 페이지 로딩 직후에도 “내가 이미 눌러둔 좋아요” 상태가 반영되어, 첫 클릭 시 좋아요 수가 맞게 감소(3 → 2)됩니다.

2.
fetchComments와 CommentResponse를 사용해 별도의 useSuspenseQuery를 추가했습니다.
→ 최초 렌더 시 서버의 댓글 목록을 받아와 localFeed.comments에 반영합니다.
댓글/답글 작성 후 QUERY_KEYS.feeds.comments(feedId)를 invalidate하여 최신 목록을 다시 불러오도록 했습니다.
기존 로컬 상태와 좋아요/북마크 로직은 그대로 유지되어, 댓글 트리 UI도 정상적으로 갱신됩니다.
이제 피드 상세 페이지는 페이지 로딩 시 지정된 엔드포인트에서 댓글을 가져오며, 새 댓글 작성 이후에도 API 호출을 통해 목록이 최신 상태로 유지됩니다.

3.
/mypage 새로고침 시 로그인 화면으로 튕기는 원인은 ProtectedRoute가 로그인 여부만 보고 즉시 리다이렉트했기 때문이었어요.
앱 최초 로드 시 AuthProvider가 /api/auth/me 요청으로 세션을 확인하는 동안 isLogin은 아직 false라 보호 라우트가 미리 /login으로 보내버렸습니다.
해결을 위해 ProtectedRoute에 loading 체크를 추가했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Starter packs now surface like state alongside engagement counts.

* **Bug Fixes**
  * Prevents unwanted redirects while authentication is loading.

* **Improvements**
  * Unified normalization ensures consistent like/bookmark/comment counts across listings and details.
  * Improved comment loading, local updates, and refresh behavior on feed and starter pack detail pages.
  * Cleaner starter pack detail UI with simplified interaction flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->