### PR TITLE
fix: stats·interactionStatus 값을 공통 헬퍼로 정규화

### DIFF
--- a/src/api/feedApi.ts
+++ b/src/api/feedApi.ts
@@ -13,6 +13,87 @@ import type {
   PageFeedLikerResponse,
 } from '@/types/Feed';
 
+type FeedStats = {
+  likeCount?: number;
+  bookmarkCount?: number;
+  commentCount?: number;
+};
+
+type FeedInteractionStatus = {
+  isLiked?: boolean;
+  isBookmarked?: boolean;
+};
+
+type RawFeedPost = Omit<
+  FeedPost,
+  'likeCount' | 'bookmarkCount' | 'commentCount' | 'isLiked' | 'isBookmarked'
+> &
+  Partial<FeedPost> & {
+    stats?: FeedStats;
+    interactionStatus?: FeedInteractionStatus;
+  };
+
+type RawFeedDetail = Omit<
+  FeedDetail,
+  'likeCount' | 'bookmarkCount' | 'commentCount' | 'isLiked' | 'isBookmarked'
+> &
+  Partial<FeedDetail> & {
+    imageUrl: string | string[];
+    stats?: FeedStats;
+    interactionStatus?: FeedInteractionStatus;
+  };
+
+const normalizeFeedMetrics = (data: {
+  likeCount?: number;
+  bookmarkCount?: number;
+  commentCount?: number;
+  isLiked?: boolean;
+  isBookmarked?: boolean;
+  stats?: FeedStats;
+  interactionStatus?: FeedInteractionStatus;
+}) => {
+  const likeCount =
+    typeof data.likeCount === 'number' ? data.likeCount : (data.stats?.likeCount ?? 0);
+  const commentCount =
+    typeof data.commentCount === 'number' ? data.commentCount : (data.stats?.commentCount ?? 0);
+  const bookmarkCount =
+    typeof data.bookmarkCount === 'number' ? data.bookmarkCount : (data.stats?.bookmarkCount ?? 0);
+  const isLiked =
+    typeof data.isLiked === 'boolean' ? data.isLiked : (data.interactionStatus?.isLiked ?? false);
+  const isBookmarked =
+    typeof data.isBookmarked === 'boolean'
+      ? data.isBookmarked
+      : (data.interactionStatus?.isBookmarked ?? false);
+
+  return { likeCount, commentCount, bookmarkCount, isLiked, isBookmarked };
+};
+
+const normalizeFeedPost = (feed: RawFeedPost): FeedPost => {
+  const { stats, interactionStatus, ...rest } = feed;
+  const metrics = normalizeFeedMetrics({ ...feed, stats, interactionStatus });
+
+  return {
+    ...rest,
+    ...metrics,
+    imageUrl: typeof rest.imageUrl === 'string' ? rest.imageUrl : rest.imageUrl || '',
+  } as FeedPost;
+};
+
+const normalizeFeedDetail = (feed: RawFeedDetail): FeedDetail => {
+  const { stats, interactionStatus, comments, hashtags, imageUrl, ...rest } = feed;
+  const metrics = normalizeFeedMetrics({ ...feed, stats, interactionStatus });
+
+  const normalizedImageUrls = Array.isArray(imageUrl) ? imageUrl : imageUrl ? [imageUrl] : [];
+
+  return {
+    ...rest,
+    ...metrics,
+    comments: comments ?? [],
+    hashtags: hashtags ?? [],
+    imageUrl: normalizedImageUrls,
+  } as FeedDetail;
+};
+
 // ==================== Feed 관련 API ====================
 
 // 피드 목록 조회 (페이지네이션)
@@ -31,8 +112,17 @@ export const fetchFeeds = async (
       params.sort = options.sort;
     }
 
-    const response = await axiosInstance.get<FeedResponse>('/api/feeds', { params });
-    return response.data;
+    const response = await axiosInstance.get<FeedResponse & { content: Array<RawFeedPost> }>(
+      '/api/feeds',
+      { params }
+    );
+
+    const normalizedContent = response.data.content.map(normalizeFeedPost);
+
+    return {
+      ...response.data,
+      content: normalizedContent,
+    };
   } catch (error) {
     console.error('Failed to fetch feeds:', error);
     throw error;
@@ -42,8 +132,8 @@ export const fetchFeeds = async (
 // 특정 피드 상세 조회
 export const fetchFeedById = async (id: number): Promise<FeedDetail> => {
   try {
-    const response = await axiosInstance.get<FeedDetail>(`/api/feeds/${id}`);
-    return response.data;
+    const response = await axiosInstance.get<RawFeedDetail>(`/api/feeds/${id}`);
+    return normalizeFeedDetail(response.data);
   } catch (error) {
     console.error(`Failed to fetch feed ${id}:`, error);
     throw error;

--- a/src/components/feed/FeedPost.styles.ts
+++ b/src/components/feed/FeedPost.styles.ts
@@ -197,7 +197,7 @@ export const CategoryTag = styled.div`
   font-weight: 500;
 `;
 
-export const FeedTypeTag = styled.div<{ $feedType: string }>`
+export const FeedTypeTag = styled.div<{ $feedType?: string }>`
   display: inline-block;
   padding: 0.25rem 0.5rem;
   margin: 0 1rem 0.75rem;

--- a/src/components/feed/FeedPost.styles.ts
+++ b/src/components/feed/FeedPost.styles.ts
@@ -61,7 +61,7 @@ export const PostImage = styled.img`
 export const PostActions = styled.div`
   display: flex;
   align-items: center;
-  padding: 0.375rem 1rem 0.5rem;
+  padding: 0.75rem 1rem;
   gap: 1.25rem;
   border-bottom: 1px solid ${tokens.colors.line.lightGray};
 `;
@@ -142,9 +142,9 @@ export const LikesCount = styled.div`
 `;
 
 export const Caption = styled.div`
-  padding: 0 1rem 0.5rem;
+  padding: 1rem 1rem 0.75rem;
   font-size: 0.875rem;
-  line-height: 1.4;
+  line-height: 1.6;
   color: ${tokens.colors.text.darkGray};
 
   ${Username} {
@@ -191,7 +191,7 @@ export const CategoryTag = styled.div`
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0 1rem 0.5rem;
+  padding: 0.5rem 1rem 0.5rem;
   font-size: 0.75rem;
   color: ${tokens.colors.orange.primary};
   font-weight: 500;
@@ -200,7 +200,7 @@ export const CategoryTag = styled.div`
 export const FeedTypeTag = styled.div<{ $feedType: string }>`
   display: inline-block;
   padding: 0.25rem 0.5rem;
-  margin: 0 1rem 0.5rem;
+  margin: 0 1rem 0.75rem;
   font-size: 0.625rem;
   font-weight: 600;
   border-radius: 0.25rem;

--- a/src/components/feed/FeedPost.tsx
+++ b/src/components/feed/FeedPost.tsx
@@ -39,6 +39,10 @@ const FeedPost = ({ post, onLike, onBookmark }: FeedPostProps) => {
     const count = post.likeCount;
     return typeof count === 'number' && !isNaN(count) ? count : 0;
   });
+  const [commentCount, setCommentCount] = useState(() => {
+    const count = post.commentCount;
+    return typeof count === 'number' && !isNaN(count) ? count : 0;
+  });
   const [isBookmarked, setIsBookmarked] = useState(post.isBookmarked ?? false);
   const [bookmarkCount, setBookmarkCount] = useState(() => {
     return typeof post.bookmarkCount === 'number' && !isNaN(post.bookmarkCount)
@@ -49,6 +53,9 @@ const FeedPost = ({ post, onLike, onBookmark }: FeedPostProps) => {
   useEffect(() => {
     setLikeCount(typeof post.likeCount === 'number' && !isNaN(post.likeCount) ? post.likeCount : 0);
     setIsLiked(post.isLiked ?? false);
+    setCommentCount(
+      typeof post.commentCount === 'number' && !isNaN(post.commentCount) ? post.commentCount : 0
+    );
 
     setBookmarkCount(
       typeof post.bookmarkCount === 'number' && !isNaN(post.bookmarkCount) ? post.bookmarkCount : 0
@@ -128,7 +135,7 @@ const FeedPost = ({ post, onLike, onBookmark }: FeedPostProps) => {
             src={post.author.profileImageUrl}
             alt={post.author.name}
             onClick={handleProfileClick}
-            style={{ cursor: 'pointer' }} 
+            style={{ cursor: 'pointer' }}
           />
           <Username onClick={handleProfileClick} style={{ cursor: 'pointer' }}>
             @{post.author.name}
@@ -171,7 +178,11 @@ const FeedPost = ({ post, onLike, onBookmark }: FeedPostProps) => {
           <EngagementIcon role="button" aria-label="댓글 달기">
             <MessageSquare size={18} strokeWidth={2} color={tokens.colors.orange.primary} />
           </EngagementIcon>
-          <EngagementCount>0</EngagementCount>
+          <EngagementCount>
+            {typeof commentCount === 'number' && !isNaN(commentCount)
+              ? commentCount.toLocaleString()
+              : '0'}
+          </EngagementCount>
         </EngagementItem>
         <BookmarkButton
           type="button"

--- a/src/mocks/feedData.ts
+++ b/src/mocks/feedData.ts
@@ -72,7 +72,10 @@ export const generateMockFeedPosts = (count: number = 20): FeedPost[] => {
       feedType,
       category,
       likeCount: 100 + i * 50,
+      commentCount: 10 + (i % 7),
+      bookmarkCount: 20 + (i % 5),
       isLiked: i % 3 === 0,
+      isBookmarked: i % 4 === 0,
       createdAt: new Date(Date.now() - i * 24 * 60 * 60 * 1000).toISOString(),
     });
   }

--- a/src/types/Feed.ts
+++ b/src/types/Feed.ts
@@ -13,9 +13,10 @@ export interface FeedPost {
     categoryName: string;
   };
   likeCount: number;
+  commentCount: number;
+  bookmarkCount: number;
   isLiked: boolean;
-  isBookmarked?: boolean;
-  bookmarkCount?: number;
+  isBookmarked: boolean;
   createdAt: string;
 }
 
@@ -154,9 +155,6 @@ export interface FeedDetail extends Omit<FeedPost, 'imageUrl' | 'author'> {
   imageUrl: string[];
   author: Member;
   comments: Comment[];
-  commentCount: number;
-  bookmarkCount: number;
-  isBookmarked: boolean;
   hashtags: FeedHashtag[] | string[];
   products?: FeedProduct[];
 }


### PR DESCRIPTION
## 요약
- 피드 목록 API 응답을 정규화해 `likeCount/commentCount/bookmarkCount`와 `isLiked/isBookmarked`를 일관되게 노출하고, 카드 컴포넌트가 댓글 수를 바로 표시하도록 수정했습니다.
- 액션 버튼 영역과 본문 사이 여백을 확대하고 줄 간격을 조정해 피드 카드 레이아웃을 스타터팩 카드와 유사하게 다듬었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Comment counts now display dynamically in feed posts
  * Added bookmark count and status tracking to feed posts

* **Style**
  * Refined feed post component styling with improved typography and spacing
  * Enhanced feed type tag appearance with better visual hierarchy and color coding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->